### PR TITLE
Fixed `spot-price` documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Documentation about `spot-price` by adding a link to the document teaching a store how to set it up.
 
 ## [1.2.0] - 2020-04-15
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Now, you can use all the blocks exported by the `product-price` app. Check out t
 | --------------------| -------- |
 | `product-list-price`         | Renders the product list price. If it is equal to the product selling price, this block will not be rendered. | 
 | `product-selling-price`      | Renders the product selling price.|
-| `product-spot-price`         | Renders the product spot price. If it is equal to the product selling price, this block will not be rendered. |
+| `product-spot-price`         | Renders the product spot price. If it is equal to the product selling price, this block will not be rendered. For more information about how to set this up in your store, check this [document](https://docs.google.com/document/d/1zguIGidi_qFtoX101J7zPsjU7-MyV0qiQvTo_dOR_w0/edit?usp=sharing).|
 | `product-installments`      | Renders the product installments. If more than one option is available, the one with the biggest number of installments will be displayed. | 
 | `product-price-savings`           | Renders the product price savings, if there is any. It can show the percentage of the discount or the value of the absolute saving. | 
 | `product-list-price-range`    | Renders the product list price range. It follows the same logic applied to the `ListPrice`: if its value is equal to the product selling price, this block is not rendered. | 


### PR DESCRIPTION
#### What does this PR do? \*

Fixed documentation about `spot-price` by adding a link to the document teaching a store how to set it up.
