### PR TITLE
Improve spot-price documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Improved the `spot-price` documentation to have more details.
 
 ### Fixed
 - Updated the README.md file with a disclaimer regarding the deprecation of Product Summary Price and Product Price block. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Improved the `spot-price` documentation to have more details.
-
-### Fixed
 - Updated the README.md file with a disclaimer regarding the deprecation of Product Summary Price and Product Price block. 
 
 ## [1.3.0] - 2020-05-11

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Now, you can use all the blocks exported by the `product-price` app. Check out t
 | --------------------| -------- |
 | `product-list-price`         | Renders the product list price. If it is equal to the product selling price, this block will not be rendered. | 
 | `product-selling-price`      | Renders the product selling price.|
-| `product-spot-price`         | Renders the product spot price. If it is equal to the product selling price, this block will not be rendered. For more information about how to set this up in your store, check this [document](https://docs.google.com/document/d/1zguIGidi_qFtoX101J7zPsjU7-MyV0qiQvTo_dOR_w0/edit?usp=sharing).|
+| `product-spot-price`         | Renders the product spot price. If it is equal to the product selling price, this block will not be rendered. This component finds the spot price by looking for the cheapest price of all installments options of count 1. For more information about how to set this up in your store, check this [document](https://docs.google.com/document/d/1zguIGidi_qFtoX101J7zPsjU7-MyV0qiQvTo_dOR_w0/edit?usp=sharing).|
 | `product-installments`      | Renders the product installments. If more than one option is available, the one with the biggest number of installments will be displayed. | 
 | `product-price-savings`           | Renders the product price savings, if there is any. It can show the percentage of the discount or the value of the absolute saving. | 
 | `product-list-price-range`    | Renders the product list price range. It follows the same logic applied to the `ListPrice`: if its value is equal to the product selling price, this block is not rendered. | 


### PR DESCRIPTION
#### What does this PR do? \*

Adds more details about how the `spot-price` component is able to find the product's spot price.
