### PR TITLE
Add `hasListPrice` on `product-selling-price`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `hasListPrice` on `product-selling-price`.
 
 ## [1.3.2] - 2020-06-03
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,7 @@ Once editing their messages, bear in mind the message variables exported by each
 | `sellingPriceValue` | `string` | Selling price value. |
 | `sellingPriceWithTax` | `string` | Selling price with tax. |
 | `taxPercentage` | `string` | Tax percentage. |
-| `hasListPrice` | `boolean` | If it has list price. |
+| `hasListPrice` | `boolean` | Whether the product has a list price (`true`) or not (`false`). |
 
 - **`product-spot-price`**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,7 @@ Once editing their messages, bear in mind the message variables exported by each
 | `sellingPriceValue` | `string` | Selling price value. |
 | `sellingPriceWithTax` | `string` | Selling price with tax. |
 | `taxPercentage` | `string` | Tax percentage. |
+| `hasListPrice` | `boolean` | If it has list price. |
 
 - **`product-spot-price`**
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -11,7 +11,7 @@
 
   "admin/list-price.description": "Values available for interpolation: '{listPriceValue}, {listPriceWithTax}, {taxPercentage}'",
   "admin/list-price.title": "List Price",
-  "admin/selling-price.description": "Values available for interpolation: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}'",
+  "admin/selling-price.description": "Values available for interpolation: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}'",
   "admin/selling-price.title": "Selling Price",
   "admin/spot-price.description": "Values available for interpolation: '{spotPrice}'",
   "admin/spot-price.title": "Spot Price",

--- a/messages/es.json
+++ b/messages/es.json
@@ -11,7 +11,7 @@
 
   "admin/list-price.description": "Valores disponibles para interpolación: '{listPriceValue}, {listPriceWithTax}, {taxPercentage}'",
   "admin/list-price.title": "Precio de Lista",
-  "admin/selling-price.description": "Valores disponibles para interpolación: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}'",
+  "admin/selling-price.description": "Valores disponibles para interpolación: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}'",
   "admin/selling-price.title": "Precio de Venta",
   "admin/spot-price.description": "Valores disponibles para interpolación: '{spotPrice}'",
   "admin/spot-price.title": "Precio en Efectivo",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -11,7 +11,7 @@
 
   "admin/list-price.description": "Valores disponiveis para interpolação: '{listPriceValue}, {listPriceWithTax}, {taxPercentage}'",
   "admin/list-price.title": "Preço de Tabela",
-  "admin/selling-price.description": "Valores disponiveis para interpolação: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}'",
+  "admin/selling-price.description": "Valores disponiveis para interpolação: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}'",
   "admin/selling-price.title": "Preço de Venda",
   "admin/spot-price.description": "Valores disponiveis para interpolação: '{spotPrice}'",
   "admin/spot-price.title": "Preço a Vista",

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -61,6 +61,7 @@ const SellingPrice: StorefrontFC<BasicPriceProps> = props => {
               <FormattedNumber value={taxPercentage} style="percent" />
             </span>
           ),
+          hasListPrice,
         }}
       />
     </span>


### PR DESCRIPTION
#### What problem is this solving?

With this feature it will be possible to display a different text on `selling-price` if it is the same as `list-price`!

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Without list price](https://iaronaraujo--storecomponents.myvtex.com/wood-clock/p)
[With list price](https://iaronaraujo--storecomponents.myvtex.com/vintage-phone/p)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![image](https://user-images.githubusercontent.com/8443580/88208317-6b0c9900-cc27-11ea-943e-fe641662e8e3.png)

=============================================================

![image](https://user-images.githubusercontent.com/8443580/88208338-71027a00-cc27-11ea-9a5b-3d8f5583d9da.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/l0He0cVv8lGggpruo/giphy.gif)
