### PR TITLE
Fix/add prevention list price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add preventions for negative savings.
 
 ## [1.5.0] - 2020-07-23
 ### Added

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -30,7 +30,6 @@ const ListPrice: StorefrontFC<BasicPriceProps> = props => {
   const listPriceWithTax = listPriceValue + listPriceValue * taxPercentage
 
   if (
-    listPriceValue === sellingPriceValue ||
     listPriceValue <= sellingPriceValue
   ) {
     return null

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -29,7 +29,10 @@ const ListPrice: StorefrontFC<BasicPriceProps> = props => {
   const { taxPercentage } = commercialOffer
   const listPriceWithTax = listPriceValue + listPriceValue * taxPercentage
 
-  if (listPriceValue === sellingPriceValue) {
+  if (
+    listPriceValue === sellingPriceValue ||
+    listPriceValue <= sellingPriceValue
+  ) {
     return null
   }
 

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -32,7 +32,7 @@ const Savings: StorefrontFC<BasicPriceProps> = props => {
   const savingsWithTax =
     savingsValue + savingsValue * commercialOffer.taxPercentage
   const savingsPercentage = savingsValue / previousPriceValue
-  if (savingsValue === 0) {
+  if (savingsValue === 0 || savingsValue <= 0) {
     return null
   }
 

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -32,7 +32,7 @@ const Savings: StorefrontFC<BasicPriceProps> = props => {
   const savingsWithTax =
     savingsValue + savingsValue * commercialOffer.taxPercentage
   const savingsPercentage = savingsValue / previousPriceValue
-  if (savingsValue === 0 || savingsValue <= 0) {
+  if (savingsValue <= 0) {
     return null
   }
 


### PR DESCRIPTION
#### What problem is this solving?

Sometimes integrations push `listPrice` with a value less than the `sellingPrice`, then it generates negative savings on front-end.

#### How to test it?
[Workspace](https://listprice--polishop.myvtex.com/utilidades-domesticas/panelas-e-frigideiras)

Navigate to https://beta--polishop.myvtex.com/utilidades-domesticas/panelas-e-frigideiras and figure out how weird it is currently.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![with fix](https://user-images.githubusercontent.com/27451066/89076924-9c881180-d357-11ea-9d91-1e394386c112.png)
![currently](https://user-images.githubusercontent.com/27451066/89077031-bc1f3a00-d357-11ea-9672-0e5ea5d7ab63.png)



#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/t22XfyAwh0Qla/giphy.gif)
