### PR TITLE
Calculate discounts based on the Spot Price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Calculate discounts based on the Spot Price
 
 ## [1.5.3] - 2020-08-04
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,10 @@ In addition to that, keep in mind the message variables for each block since you
 | `listPriceWithTax` | `string` | List price value with tax. |
 | `taxPercentage` | `string` | Tax percentage. |
 
+| Prop name | Type | Description | Default value |
+| --- | --- | --- | --- |
+| `shouldAlwaysShow` | `boolean` | Whether the product list price should always show | `false` |
+
 -  **`product-selling-price`**
 
 | Message variable | Type | Description |
@@ -143,10 +147,6 @@ In addition to that, keep in mind the message variables for each block since you
 | `savingsValue` | `string` | Difference between previous product price and the new one. |
 | `savingsWithTax` | `string` | Difference between previous product price and the new one with taxes. |
 | `savingsPercentage` | `string` | Percentage of savings. |
-
-| Prop name | Type | Description | Default value |
-| --- | --- | --- | --- |
-| `usingSpotPrice` | `boolean` | Calculate discounts based on the Spot Price | `false` |
 
 - **`product-list-price-range`**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,7 +109,7 @@ In addition to that, keep in mind the message variables for each block since you
 
 | Prop name | Type | Description | Default value |
 | --- | --- | --- | --- |
-| `shouldAlwaysShow` | `boolean` | Whether the product list price should always show | `false` |
+| `shouldAlwaysShow` | `boolean` | Whether the product list price should always be displayed (`true`) or not (`false`). | `false` |
 
 -  **`product-selling-price`**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,9 +106,6 @@ In addition to that, keep in mind the message variables for each block since you
 | `listPriceValue` | `string` | List price value. |
 | `listPriceWithTax` | `string` | List price value with tax. |
 | `taxPercentage` | `string` | Tax percentage. |
-
-| Prop name | Type | Description | Default value |
-| --- | --- | --- | --- |
 | `shouldAlwaysShow` | `boolean` | Whether the product list price should always be displayed (`true`) or not (`false`). | `false` |
 
 -  **`product-selling-price`**

--- a/docs/README.md
+++ b/docs/README.md
@@ -144,6 +144,10 @@ In addition to that, keep in mind the message variables for each block since you
 | `savingsWithTax` | `string` | Difference between previous product price and the new one with taxes. |
 | `savingsPercentage` | `string` | Percentage of savings. |
 
+| Prop name | Type | Description | Default value |
+| --- | --- | --- | --- |
+| `usingSpotPrice` | `boolean` | Calculate discounts based on the Spot Price | `false` |
+
 - **`product-list-price-range`**
 
 | Message variables | Type | Description |

--- a/messages/en.json
+++ b/messages/en.json
@@ -14,7 +14,7 @@
   "admin/selling-price.title": "Selling Price",
   "admin/spot-price.description": "Values available for interpolation: '{spotPrice}'",
   "admin/spot-price.title": "Spot Price",
-  "admin/savings.description": "Values available for interpolation: '{newPriceValue}, {previousPriceValue}, {savingsValue}, {savingsPercentage}, {savingsWithTax}'",
+  "admin/savings.description": "Values available for interpolation: '{newPriceValue}, {previousPriceValue}, {savingsValue}, {savingsPercentage}, {savingsWithTax}, {spotPriceSavingsValue}, {spotPriceSavingsWithTax}, {spotPriceSavingsPercentage}'",
   "admin/savings.title": "Savings",
   "admin/installments.description": "Values available for interpolation: '{installmentsNumber}, {installmentValue}, {installmentsTotalValue}, {interestRate}, {hasInterest}, {paymentSystemName}'",
   "admin/installments.title": "Installments",

--- a/messages/es.json
+++ b/messages/es.json
@@ -14,7 +14,7 @@
   "admin/selling-price.title": "Precio de Venta",
   "admin/spot-price.description": "Valores disponibles para interpolación: '{spotPrice}'",
   "admin/spot-price.title": "Precio en Efectivo",
-  "admin/savings.description": "Valores disponibles para interpolación: '{newPriceValue}, {previousPriceValue}, {savingsValue}, {savingsPercentage}, {savingsWithTax}'",
+  "admin/savings.description": "Valores disponibles para interpolación: '{newPriceValue}, {previousPriceValue}, {savingsValue}, {savingsPercentage}, {savingsWithTax}, {spotPriceSavingsValue}, {spotPriceSavingsWithTax}, {spotPriceSavingsPercentage}'",
   "admin/savings.title": "Ahorros",
   "admin/installments.description": "Valores disponibles para interpolación: '{installmentsNumber}, {installmentValue}, {installmentsTotalValue}, {interestRate}, {hasInterest}, {paymentSystemName}'",
   "admin/installments.title": "Cuotas",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -14,7 +14,7 @@
   "admin/selling-price.title": "Preço de Venda",
   "admin/spot-price.description": "Valores disponiveis para interpolação: '{spotPrice}'",
   "admin/spot-price.title": "Preço a Vista",
-  "admin/savings.description": "Valores disponiveis para interpolação: '{newPriceValue}, {previousPriceValue}, {savingsValue}, {savingsPercentage}, {savingsWithTax}'",
+  "admin/savings.description": "Valores disponiveis para interpolação: '{newPriceValue}, {previousPriceValue}, {savingsValue}, {savingsPercentage}, {savingsWithTax}, {spotPriceSavingsValue}, {spotPriceSavingsWithTax}, {spotPriceSavingsPercentage}'",
   "admin/savings.title": "Economias",
   "admin/installments.description": "Valores disponiveis para interpolação: '{installmentsNumber}, {installmentValue}, {installmentsTotalValue}, {interestRate}, {hasInterest}, {paymentSystemName}'",
   "admin/installments.title": "Parcelamento",

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -14,27 +14,28 @@ const CSS_HANDLES = [
   'taxPercentage',
 ] as const
 
-interface ListPriceProps {
-  usingSpotPrice?: boolean
+interface Props {
+  shouldAlwaysShow?: boolean
 }
 
-const ListPrice: StorefrontFC<BasicPriceProps & ListPriceProps> = props => {
-  const { message, markers, usingSpotPrice } = props
+const ListPrice: StorefrontFC<BasicPriceProps & Props> = props => {
+  const { message, markers, shouldAlwaysShow } = props
   const handles = useCssHandles(CSS_HANDLES)
   const { selectedItem } = useContext(ProductContext)
 
   const commercialOffer = selectedItem?.sellers[0]?.commertialOffer
+
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null
   }
 
   const listPriceValue: number = commercialOffer.ListPrice
-  const spotPriceValue = commercialOffer.spotPrice ?? 0
-  const sellingPriceValue = spotPriceValue < commercialOffer.Price && usingSpotPrice ? spotPriceValue : commercialOffer.Price
+  const sellingPriceValue = commercialOffer.Price
+
   const { taxPercentage } = commercialOffer
   const listPriceWithTax = listPriceValue + listPriceValue * taxPercentage
 
-  if (listPriceValue <= sellingPriceValue) {
+  if (listPriceValue <= sellingPriceValue && !shouldAlwaysShow) {
     return null
   }
 

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -14,8 +14,12 @@ const CSS_HANDLES = [
   'taxPercentage',
 ] as const
 
-const ListPrice: StorefrontFC<BasicPriceProps> = props => {
-  const { message, markers } = props
+interface ListPriceProps {
+  usingSpotPrice?: boolean
+}
+
+const ListPrice: StorefrontFC<BasicPriceProps & ListPriceProps> = props => {
+  const { message, markers, usingSpotPrice } = props
   const handles = useCssHandles(CSS_HANDLES)
   const { selectedItem } = useContext(ProductContext)
 
@@ -25,7 +29,8 @@ const ListPrice: StorefrontFC<BasicPriceProps> = props => {
   }
 
   const listPriceValue: number = commercialOffer.ListPrice
-  const sellingPriceValue = commercialOffer.Price
+  const spotPriceValue = commercialOffer.spotPrice ?? 0
+  const sellingPriceValue = spotPriceValue < commercialOffer.Price && usingSpotPrice ? spotPriceValue : commercialOffer.Price
   const { taxPercentage } = commercialOffer
   const listPriceWithTax = listPriceValue + listPriceValue * taxPercentage
 

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -16,8 +16,12 @@ const CSS_HANDLES = [
   'savingsPercentage',
 ] as const
 
-const Savings: StorefrontFC<BasicPriceProps> = props => {
-  const { message, markers } = props
+interface SavingsProps {
+  usingSpotPrice?: boolean
+}
+
+const Savings: StorefrontFC<BasicPriceProps & SavingsProps> = props => {
+  const { message, markers, usingSpotPrice } = props
   const handles = useCssHandles(CSS_HANDLES)
   const { selectedItem } = useContext(ProductContext)
 
@@ -27,7 +31,9 @@ const Savings: StorefrontFC<BasicPriceProps> = props => {
   }
 
   const previousPriceValue = commercialOffer.ListPrice
-  const newPriceValue = commercialOffer.Price
+  const spotPriceValue = commercialOffer.spotPrice ?? 0
+	const newPriceValue = spotPriceValue < commercialOffer.Price && usingSpotPrice ? spotPriceValue : commercialOffer.Price
+
   const savingsValue = previousPriceValue - newPriceValue
   const savingsWithTax =
     savingsValue + savingsValue * commercialOffer.taxPercentage

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -14,14 +14,13 @@ const CSS_HANDLES = [
   'savingsValue',
   'savingsWithTax',
   'savingsPercentage',
+  'spotPriceSavingsValue',
+  'spotPriceSavingsWithTax',
+  'spotPriceSavingsPercentage',
 ] as const
 
-interface SavingsProps {
-  usingSpotPrice?: boolean
-}
-
-const Savings: StorefrontFC<BasicPriceProps & SavingsProps> = props => {
-  const { message, markers, usingSpotPrice } = props
+const Savings: StorefrontFC<BasicPriceProps> = props => {
+  const { message, markers } = props
   const handles = useCssHandles(CSS_HANDLES)
   const { selectedItem } = useContext(ProductContext)
 
@@ -31,14 +30,21 @@ const Savings: StorefrontFC<BasicPriceProps & SavingsProps> = props => {
   }
 
   const previousPriceValue = commercialOffer.ListPrice
-  const spotPriceValue = commercialOffer.spotPrice ?? 0
-	const newPriceValue = spotPriceValue < commercialOffer.Price && usingSpotPrice ? spotPriceValue : commercialOffer.Price
+  const spotPriceValue = commercialOffer.spotPrice
+  const newPriceValue = commercialOffer.Price
 
   const savingsValue = previousPriceValue - newPriceValue
   const savingsWithTax =
     savingsValue + savingsValue * commercialOffer.taxPercentage
   const savingsPercentage = savingsValue / previousPriceValue
-  if (savingsValue <= 0) {
+
+  const spotPriceSavingsValue = previousPriceValue - spotPriceValue
+  const spotPriceSavingsWithTax =
+    spotPriceSavingsValue +
+    spotPriceSavingsValue * commercialOffer.taxPercentage
+  const spotPriceSavingsPercentage = spotPriceSavingsValue / previousPriceValue
+
+  if (savingsValue <= 0 && spotPriceSavingsValue <= 0) {
     return null
   }
 
@@ -75,6 +81,33 @@ const Savings: StorefrontFC<BasicPriceProps & SavingsProps> = props => {
           savingsPercentage: (
             <span key="savingsPercentage" className={handles.savingsPercentage}>
               <FormattedNumber value={savingsPercentage} style="percent" />
+            </span>
+          ),
+          spotPriceSavingsValue: (
+            <span
+              key="spotPriceSavingsValue"
+              className={handles.spotPriceSavingsValue}
+            >
+              <FormattedNumber value={spotPriceSavingsValue} />
+            </span>
+          ),
+          spotPriceSavingsWithTax: (
+            <span
+              key="spotPriceSavingsWithTax"
+              className={handles.spotPriceSavingsWithTax}
+            >
+              <FormattedNumber value={spotPriceSavingsWithTax} />
+            </span>
+          ),
+          spotPriceSavingsPercentage: (
+            <span
+              key="spotPriceSavingsPercentage"
+              className={handles.spotPriceSavingsPercentage}
+            >
+              <FormattedNumber
+                value={spotPriceSavingsPercentage}
+                style="percent"
+              />
             </span>
           ),
         }}


### PR DESCRIPTION
#### What problem is this solving?
Add new feature to calculate discounts based on the Spot Price.

#### How to test it?

[Workspace](https://spotprice--carrefourbr.myvtex.com/smartphone-motorola-one-hyper-128gb-rosa-boreal-4g-tela-6-5-pol-camera-dupla-64mp-selfie-32mp-android-10-5906032/p)

#### Screenshots or example usage:

Using the spot price and the list price before the changes:
![image](https://user-images.githubusercontent.com/49173685/91315431-0dbbb880-e78e-11ea-9c4e-896bc58bcc73.png)

After changes:
![image](https://user-images.githubusercontent.com/49173685/91315530-275d0000-e78e-11ea-920c-0557cb56e528.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media0.giphy.com/media/Zd6B2US0rnH0GVZi2i/giphy.gif?cid=ecf05e47iqs53xw8g3u0vge0s7c33iorj0s8m4h4swnms6de&rid=giphy.gif)
