### PR TITLE
Use typings exported from vtex.product-context app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Mocked type definitions from `vtex.product-context` in favor of the actual ones.
 
 ## [1.6.0] - 2020-09-04 [YANKED]
 ### Added

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
       "eslint --fix",
       "prettier --write"
     ],
+    "*.{json,graphql,gql}": [
+      "prettier --write"
+    ],
     "*.json": [
       "prettier --write"
     ]

--- a/react/InstallmentsList.tsx
+++ b/react/InstallmentsList.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
-import { ProductContext } from 'vtex.product-context'
+import { useProduct } from 'vtex.product-context'
 
 import {
   Installments,
@@ -16,10 +16,11 @@ interface Props {
 
 function InstallmentsList(props: Props) {
   const { children } = props
-  const { selectedItem } = useContext(ProductContext)
+  const productContextValue = useProduct()
   const handles = useCssHandles(CSS_HANDLES)
 
-  const commercialOffer = selectedItem?.sellers[0]?.commertialOffer
+  const commercialOffer =
+    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
 
   if (
     !commercialOffer?.Installments ||

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { defineMessages, FormattedNumber } from 'react-intl'
-import { ProductContext } from 'vtex.product-context'
+import { useProduct } from 'vtex.product-context'
 import { FormattedCurrency } from 'vtex.format-currency'
 import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
@@ -17,9 +17,11 @@ const CSS_HANDLES = [
 const ListPrice: StorefrontFC<BasicPriceProps> = props => {
   const { message, markers } = props
   const handles = useCssHandles(CSS_HANDLES)
-  const { selectedItem } = useContext(ProductContext)
+  const productContextValue = useProduct()
 
-  const commercialOffer = selectedItem?.sellers[0]?.commertialOffer
+  const commercialOffer =
+    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null
   }

--- a/react/ListPriceRange.tsx
+++ b/react/ListPriceRange.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { defineMessages } from 'react-intl'
-import { ProductContext } from 'vtex.product-context'
+import { useProduct } from 'vtex.product-context'
 import { FormattedCurrency } from 'vtex.format-currency'
 import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
@@ -20,9 +20,10 @@ const CSS_HANDLES = [
 const ListPriceRange: StorefrontFC<PriceRangeProps> = props => {
   const { message, noRangeMessage, markers } = props
   const handles = useCssHandles(CSS_HANDLES)
-  const { product, selectedItem } = useContext(ProductContext)
+  const productContextValue = useProduct()
 
-  const priceRange = product?.priceRange
+  const priceRange = productContextValue?.product?.priceRange
+
   if (!priceRange) {
     return null
   }
@@ -34,7 +35,9 @@ const ListPriceRange: StorefrontFC<PriceRangeProps> = props => {
     return null
   }
 
-  const commercialOffer = selectedItem?.sellers[0]?.commertialOffer
+  const commercialOffer =
+    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null
   }

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { defineMessages, FormattedNumber } from 'react-intl'
-import { ProductContext } from 'vtex.product-context'
+import { useProduct } from 'vtex.product-context'
 import { FormattedCurrency } from 'vtex.format-currency'
 import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
@@ -19,9 +19,11 @@ const CSS_HANDLES = [
 const Savings: StorefrontFC<BasicPriceProps> = props => {
   const { message, markers } = props
   const handles = useCssHandles(CSS_HANDLES)
-  const { selectedItem } = useContext(ProductContext)
+  const productContextValue = useProduct()
 
-  const commercialOffer = selectedItem?.sellers[0]?.commertialOffer
+  const commercialOffer =
+    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null
   }
@@ -31,7 +33,9 @@ const Savings: StorefrontFC<BasicPriceProps> = props => {
   const savingsValue = previousPriceValue - newPriceValue
   const savingsWithTax =
     savingsValue + savingsValue * commercialOffer.taxPercentage
+
   const savingsPercentage = savingsValue / previousPriceValue
+
   if (savingsValue <= 0) {
     return null
   }

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { defineMessages, FormattedNumber } from 'react-intl'
-import { ProductContext } from 'vtex.product-context'
+import { useProduct } from 'vtex.product-context'
 import { FormattedCurrency } from 'vtex.format-currency'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
@@ -17,12 +17,15 @@ const CSS_HANDLES = [
 const SellingPrice: StorefrontFC<BasicPriceProps> = props => {
   const { message, markers } = props
   const handles = useCssHandles(CSS_HANDLES)
-  const { selectedItem } = useContext(ProductContext)
+  const productContextValue = useProduct()
 
-  const commercialOffer = selectedItem?.sellers[0]?.commertialOffer
+  const commercialOffer =
+    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null
   }
+
   const sellingPriceValue: number = commercialOffer.Price
   const listPriceValue = commercialOffer.ListPrice
   const { taxPercentage } = commercialOffer

--- a/react/SellingPriceRange.tsx
+++ b/react/SellingPriceRange.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { defineMessages } from 'react-intl'
-import { ProductContext } from 'vtex.product-context'
+import { useProduct } from 'vtex.product-context'
 import { FormattedCurrency } from 'vtex.format-currency'
 import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
@@ -20,14 +20,17 @@ const CSS_HANDLES = [
 const SellingPriceRange: StorefrontFC<PriceRangeProps> = props => {
   const { message, noRangeMessage, markers } = props
   const handles = useCssHandles(CSS_HANDLES)
-  const { product, selectedItem } = useContext(ProductContext)
+  const productContextValue = useProduct()
 
-  const priceRange = product?.priceRange
+  const priceRange = productContextValue?.product?.priceRange
+
   if (!priceRange) {
     return null
   }
 
-  const commercialOffer = selectedItem?.sellers[0]?.commertialOffer
+  const commercialOffer =
+    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null
   }

--- a/react/SpotPrice.tsx
+++ b/react/SpotPrice.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { defineMessages } from 'react-intl'
-import { ProductContext } from 'vtex.product-context'
+import { useProduct } from 'vtex.product-context'
 import { FormattedCurrency } from 'vtex.format-currency'
 import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
@@ -12,9 +12,11 @@ const CSS_HANDLES = ['spotPrice', 'spotPriceValue'] as const
 const SpotPrice: StorefrontFC<BasicPriceProps> = props => {
   const { message, markers } = props
   const handles = useCssHandles(CSS_HANDLES)
-  const { selectedItem } = useContext(ProductContext)
+  const productContextValue = useProduct()
 
-  const commercialOffer = selectedItem?.sellers[0]?.commertialOffer
+  const commercialOffer =
+    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null
   }

--- a/react/components/InstallmentsRenderer.tsx
+++ b/react/components/InstallmentsRenderer.tsx
@@ -3,9 +3,9 @@ import { FormattedNumber } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 import { FormattedCurrency } from 'vtex.format-currency'
 import { IOMessageWithMarkers } from 'vtex.native-types'
+import { ProductTypes } from 'vtex.product-context'
 
 import { BasicPriceProps } from '../types'
-import { Installments } from './InstallmentsContext'
 
 const CSS_HANDLES = [
   'installments',
@@ -17,7 +17,7 @@ const CSS_HANDLES = [
 ] as const
 
 interface Props extends BasicPriceProps {
-  installments: Installments
+  installments: Partial<ProductTypes.Installment>
 }
 
 function InstallmentsRenderer(props: Props) {
@@ -46,7 +46,7 @@ function InstallmentsRenderer(props: Props) {
               key="installmentsNumber"
               className={handles.installmentsNumber}
             >
-              <FormattedNumber value={NumberOfInstallments} />
+              <FormattedNumber value={NumberOfInstallments!} />
             </span>
           ),
           installmentValue: (
@@ -64,7 +64,7 @@ function InstallmentsRenderer(props: Props) {
           ),
           interestRate: (
             <span key="interestRate" className={handles.interestRate}>
-              <FormattedNumber value={InterestRate} style="percent" />
+              <FormattedNumber value={InterestRate!} style="percent" />
             </span>
           ),
           paymentSystemName: (

--- a/react/components/InstallmentsRenderer.tsx
+++ b/react/components/InstallmentsRenderer.tsx
@@ -46,7 +46,9 @@ function InstallmentsRenderer(props: Props) {
               key="installmentsNumber"
               className={handles.installmentsNumber}
             >
-              <FormattedNumber value={NumberOfInstallments!} />
+              {NumberOfInstallments && (
+                <FormattedNumber value={NumberOfInstallments} />
+              )}
             </span>
           ),
           installmentValue: (
@@ -64,7 +66,9 @@ function InstallmentsRenderer(props: Props) {
           ),
           interestRate: (
             <span key="interestRate" className={handles.interestRate}>
-              <FormattedNumber value={InterestRate!} style="percent" />
+              {InterestRate && (
+                <FormattedNumber value={InterestRate} style="percent" />
+              )}
             </span>
           ),
           paymentSystemName: (

--- a/react/modules/pickInstallments.ts
+++ b/react/modules/pickInstallments.ts
@@ -1,4 +1,3 @@
-// import { Installments } from '../components/InstallmentsContext'
 import { ProductTypes } from 'vtex.product-context'
 
 type ClusterBy = keyof ProductTypes.Installment

--- a/react/modules/pickInstallments.ts
+++ b/react/modules/pickInstallments.ts
@@ -1,6 +1,7 @@
-import { Installments } from '../components/InstallmentsContext'
+// import { Installments } from '../components/InstallmentsContext'
+import { ProductTypes } from 'vtex.product-context'
 
-type ClusterBy = keyof Installments
+type ClusterBy = keyof ProductTypes.Installment
 
 /**
  * Pick which installments should be used, first it cluster all installments
@@ -10,7 +11,7 @@ type ClusterBy = keyof Installments
  * @param clusterBy
  */
 export default function pickInstallments(
-  installmentsList: Installments[],
+  installmentsList: ProductTypes.Installment[],
   clusterBy: ClusterBy
 ) {
   const clusteredInstallments = clusterInstallments(installmentsList, clusterBy)
@@ -28,10 +29,10 @@ export default function pickInstallments(
  * @param clusterBy Key to be clustered by
  */
 function clusterInstallments(
-  installmentsList: Installments[],
-  clusterBy: keyof Installments
+  installmentsList: ProductTypes.Installment[],
+  clusterBy: keyof ProductTypes.Installment
 ) {
-  const clusteredInstallments: Record<string, Installments[]> = {}
+  const clusteredInstallments: Record<string, ProductTypes.Installment[]> = {}
 
   for (const installment of installmentsList) {
     if (!clusteredInstallments[installment[clusterBy]]) {
@@ -52,7 +53,7 @@ function clusterInstallments(
  * @param clusterBy
  */
 function pickMaxOption(
-  clusteredInstallments: Record<string, Installments[]>,
+  clusteredInstallments: Record<string, ProductTypes.Installment[]>,
   clusterBy: ClusterBy
 ) {
   const clusterKeys = Object.keys(clusteredInstallments)

--- a/react/package.json
+++ b/react/package.json
@@ -22,7 +22,11 @@
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.5.8",
     "typescript": "3.8.3",
-    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles"
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
+    "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency",
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
+    "vtex.product-context": "https://sellername--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599136488/public/@types/vtex.product-context",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime"
   },
   "version": "1.6.0"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,7 @@
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
-    "vtex.product-context": "https://victormiranda4--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599137148/public/@types/vtex.product-context",
+    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.2/public/@types/vtex.product-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime"
   },
   "version": "1.6.0"

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,7 @@
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
-    "vtex.product-context": "https://sellername--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599136488/public/@types/vtex.product-context",
+    "vtex.product-context": "https://victormiranda4--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599137148/public/@types/vtex.product-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime"
   },
   "version": "1.6.0"

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -2,8 +2,21 @@
   "extends": "@vtex/tsconfig",
   "compilerOptions": {
     "noEmitOnError": false,
-    "typeRoots": ["node_modules/@types"],
-    "types": ["node", "jest", "graphql"]
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "types": [
+      "node",
+      "jest",
+      "graphql"
+    ],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "es2017"
   },
-  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"]
+  "include": [
+    "./typings/*.d.ts",
+    "./**/*.tsx",
+    "./**/*.ts"
+  ]
 }

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -1,3 +1,0 @@
-declare module 'vtex.product-context' {
-  const ProductContext: any
-}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4867,9 +4867,9 @@ verror@1.10.0:
   version "0.7.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
 
-"vtex.product-context@https://victormiranda4--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599137148/public/@types/vtex.product-context":
-  version "0.8.1"
-  resolved "https://victormiranda4--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599137148/public/@types/vtex.product-context#282b1eeb7448f8e614e4e1f859db2a31309968eb"
+"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.2/public/@types/vtex.product-context":
+  version "0.8.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.2/public/@types/vtex.product-context#e149c4f680faf1bfdc2b30a136f6597bf9ef37b7"
 
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime":
   version "8.112.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4867,9 +4867,9 @@ verror@1.10.0:
   version "0.7.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
 
-"vtex.product-context@https://sellername--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599136488/public/@types/vtex.product-context":
+"vtex.product-context@https://victormiranda4--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599137148/public/@types/vtex.product-context":
   version "0.8.1"
-  resolved "https://sellername--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599136488/public/@types/vtex.product-context#728d04d9913711d178058527d5da5e0d704a74bc"
+  resolved "https://victormiranda4--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599137148/public/@types/vtex.product-context#282b1eeb7448f8e614e4e1f859db2a31309968eb"
 
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime":
   version "8.112.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4855,9 +4855,25 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles":
-  version "0.4.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles#62ee61d1bb9efdc919e5cf4bb44fabcf9050d255"
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
+  version "0.4.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
+
+"vtex.format-currency@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency":
+  version "0.1.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency#a36aa61ff95701388c0c793b8a7539b0c3d9dcf3"
+
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types":
+  version "0.7.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
+
+"vtex.product-context@https://sellername--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599136488/public/@types/vtex.product-context":
+  version "0.8.1"
+  resolved "https://sellername--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-context@0.8.1+build1599136488/public/@types/vtex.product-context#728d04d9913711d178058527d5da5e0d704a74bc"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime":
+  version "8.112.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime#d24f7d970497a80e1e38864db09bbe5da61e0696"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
#### What problem is this solving?

This PR removes the mocked type definitions for the `vtex.product-context` app, since it did not export its typings before.

#### How to test it?

There should be nothing different from `master` in this [Workspace](https://victormiranda4--storecomponents.myvtex.com/blouse-with-knot/p).

#### Screenshots or example usage:

Not that impressive, but it does look good 😍 .

<img width="978" alt="Screen Shot 2020-09-03 at 09 49 03" src="https://user-images.githubusercontent.com/27777263/92116811-b68b9880-edca-11ea-9ec8-eedca7c3cad8.png">

#### Related to / Depends on

Depends on: https://github.com/vtex-apps/product-context/pull/32.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/V1QKlDs9bb6Ss/giphy.gif)
