### PR TITLE
hide saving when product-summary is loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Hide `Saving` component when `product-summary` is loading.
 
 ## [1.8.0] - 2020-09-10
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
     "vtex.native-types": "0.x",
     "vtex.product-context": "0.x",
     "vtex.format-currency": "0.x",
-    "vtex.css-handles": "0.x"
+    "vtex.css-handles": "0.x",
+    "vtex.product-summary-context": "0.x"
   },
   "registries": [
     "smartcheckout"

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -4,6 +4,7 @@ import { useProduct } from 'vtex.product-context'
 import { FormattedCurrency } from 'vtex.format-currency'
 import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
+import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
 
 import { StorefrontFC, BasicPriceProps } from './types'
 
@@ -20,11 +21,16 @@ const Savings: StorefrontFC<BasicPriceProps> = props => {
   const { message, markers } = props
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
+  const productSummaryValue = useProductSummary()
 
   const commercialOffer =
     productContextValue?.selectedItem?.sellers[0]?.commertialOffer
 
-  if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
+  if (
+    !commercialOffer ||
+    commercialOffer?.AvailableQuantity <= 0 ||
+    productSummaryValue?.isLoading
+  ) {
     return null
   }
 


### PR DESCRIPTION
#### What problem is this solving?

Hide `Saving` component when `product-summary` is loading.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago3--carrefourbrfood.myvtex.com/Alimentos-e-Bebidas/Bebidas?crfint=hm-tlink|alimentos-e-bebidas|1|bebidas|2)

