### PR TITLE
Feature: Multiply by selected quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `multiplyBySelectedQuantity` prop
 
 ## [1.9.0] - 2020-09-22
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ Every block in this app only has four props in common:
 | `markers`           |`[string]` | IDs of your choosing to identify the block's rendered message and customize it using the admin's Site Editor. Learn how to use them accessing the documentation on [Using the Markers prop to customize a block's message](https://vtex.io/docs/recipes/style/using-the-markers-prop-to-customize-a-blocks-message). Notice the following: a block's message can also be customized in the Store Theme source code using the `message` prop. |`[]`|
 |  `blockClass`  |  `string`  |  Block  ID  of your choosing to  be  used  in [CSS  customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization#using-the-blockclass-property).  |  `undefined`  |
 |  `message`  |  `string`  |  Defines the block's default text i.e. the block message. You can also define which text message a block will render on the UI using the admin's Site Editor.  |  `undefined`  |
-|  `multiplyBySelectedQuantity`  |  `boolean`  |  Displays the price multiplied by the selected quantity eg `vtex.quantity-selector` |  `false`  |
+|  `multiplyBySelectedQuantity`  |  `boolean`  |  Displays the price multiplied by selected quantity value eg `vtex.quantity-selector`. ⚠️ Warning: this will not look up in to Promotions and Taxes module. |  `false`  |
 
 For example:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,13 +65,14 @@ For example:
 },
 ```
 
-Every block in this app only has three props in common:
+Every block in this app only has four props in common:
 
 | Prop name          | Type      |  Description | Default value |
 | --------------------| ----------|--------------|---------------|
 | `markers`           |`[string]` | IDs of your choosing to identify the block's rendered message and customize it using the admin's Site Editor. Learn how to use them accessing the documentation on [Using the Markers prop to customize a block's message](https://vtex.io/docs/recipes/style/using-the-markers-prop-to-customize-a-blocks-message). Notice the following: a block's message can also be customized in the Store Theme source code using the `message` prop. |`[]`|
 |  `blockClass`  |  `string`  |  Block  ID  of your choosing to  be  used  in [CSS  customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization#using-the-blockclass-property).  |  `undefined`  |
 |  `message`  |  `string`  |  Defines the block's default text i.e. the block message. You can also define which text message a block will render on the UI using the admin's Site Editor.  |  `undefined`  |
+|  `multiplyBySelectedQuantity`  |  `boolean`  |  Displays the price multiplied by the selected quantity eg `vtex.quantity-selector` |  `false`  |
 
 For example:
 

--- a/react/Installments.tsx
+++ b/react/Installments.tsx
@@ -6,7 +6,7 @@ import { StorefrontFC, BasicPriceProps } from './types'
 import InstallmentsRenderer from './components/InstallmentsRenderer'
 
 const Installments: StorefrontFC<BasicPriceProps> = props => {
-  const { message, markers, multiplyQuantity = false } = props
+  const { message, markers, multiplyBySelectedQuantity = false } = props
   const productContextValue = useProduct()
   const commercialOffer =
     productContextValue?.selectedItem?.sellers[0]?.commertialOffer
@@ -39,7 +39,7 @@ const Installments: StorefrontFC<BasicPriceProps> = props => {
       message={message}
       markers={markers}
       installments={maxInstallments ?? {}}
-      multiplyQuantity={multiplyQuantity}
+      multiplyBySelectedQuantity={multiplyBySelectedQuantity}
       selectedQuantity={selectedQuantity}
     />
   )

--- a/react/Installments.tsx
+++ b/react/Installments.tsx
@@ -6,10 +6,11 @@ import { StorefrontFC, BasicPriceProps } from './types'
 import InstallmentsRenderer from './components/InstallmentsRenderer'
 
 const Installments: StorefrontFC<BasicPriceProps> = props => {
-  const { message, markers } = props
+  const { message, markers, multiplyQuantity = false } = props
   const productContextValue = useProduct()
   const commercialOffer =
     productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const selectedQuantity = productContextValue?.selectedQuantity ?? 1
 
   if (
     !commercialOffer?.Installments ||
@@ -38,6 +39,8 @@ const Installments: StorefrontFC<BasicPriceProps> = props => {
       message={message}
       markers={markers}
       installments={maxInstallments ?? {}}
+      multiplyQuantity={multiplyQuantity}
+      selectedQuantity={selectedQuantity}
     />
   )
 }

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -15,9 +15,11 @@ const CSS_HANDLES = [
 ] as const
 
 const ListPrice: StorefrontFC<BasicPriceProps> = props => {
-  const { message, markers } = props
+  const { message, markers, multiplyQuantity = false } = props
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
+
+  const selectedQuantity = productContextValue?.selectedQuantity ?? 1
 
   const commercialOffer =
     productContextValue?.selectedItem?.sellers[0]?.commertialOffer
@@ -26,8 +28,14 @@ const ListPrice: StorefrontFC<BasicPriceProps> = props => {
     return null
   }
 
-  const listPriceValue: number = commercialOffer.ListPrice
-  const sellingPriceValue = commercialOffer.Price
+  const listPriceValue: number = multiplyQuantity
+    ? commercialOffer.ListPrice * selectedQuantity
+    : commercialOffer.ListPrice
+
+  const sellingPriceValue = multiplyQuantity
+    ? commercialOffer.Price * selectedQuantity
+    : commercialOffer.Price
+
   const { taxPercentage } = commercialOffer
   const listPriceWithTax = listPriceValue + listPriceValue * taxPercentage
 

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -15,7 +15,7 @@ const CSS_HANDLES = [
 ] as const
 
 const ListPrice: StorefrontFC<BasicPriceProps> = props => {
-  const { message, markers, multiplyQuantity = false } = props
+  const { message, markers, multiplyBySelectedQuantity = false } = props
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
 
@@ -28,11 +28,11 @@ const ListPrice: StorefrontFC<BasicPriceProps> = props => {
     return null
   }
 
-  const listPriceValue: number = multiplyQuantity
+  const listPriceValue: number = multiplyBySelectedQuantity
     ? commercialOffer.ListPrice * selectedQuantity
     : commercialOffer.ListPrice
 
-  const sellingPriceValue = multiplyQuantity
+  const sellingPriceValue = multiplyBySelectedQuantity
     ? commercialOffer.Price * selectedQuantity
     : commercialOffer.Price
 

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -15,7 +15,7 @@ const CSS_HANDLES = [
 ] as const
 
 const SellingPrice: StorefrontFC<BasicPriceProps> = props => {
-  const { message, markers, multiplyQuantity = false } = props
+  const { message, markers, multiplyBySelectedQuantity = false } = props
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
 
@@ -28,11 +28,11 @@ const SellingPrice: StorefrontFC<BasicPriceProps> = props => {
     return null
   }
 
-  const listPriceValue: number = multiplyQuantity
+  const listPriceValue: number = multiplyBySelectedQuantity
     ? commercialOffer.ListPrice * selectedQuantity
     : commercialOffer.ListPrice
 
-  const sellingPriceValue = multiplyQuantity
+  const sellingPriceValue = multiplyBySelectedQuantity
     ? commercialOffer.Price * selectedQuantity
     : commercialOffer.Price
 

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -15,9 +15,11 @@ const CSS_HANDLES = [
 ] as const
 
 const SellingPrice: StorefrontFC<BasicPriceProps> = props => {
-  const { message, markers } = props
+  const { message, markers, multiplyQuantity = false } = props
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
+
+  const selectedQuantity = productContextValue?.selectedQuantity ?? 1
 
   const commercialOffer =
     productContextValue?.selectedItem?.sellers[0]?.commertialOffer
@@ -26,8 +28,14 @@ const SellingPrice: StorefrontFC<BasicPriceProps> = props => {
     return null
   }
 
-  const sellingPriceValue: number = commercialOffer.Price
-  const listPriceValue = commercialOffer.ListPrice
+  const listPriceValue: number = multiplyQuantity
+    ? commercialOffer.ListPrice * selectedQuantity
+    : commercialOffer.ListPrice
+
+  const sellingPriceValue = multiplyQuantity
+    ? commercialOffer.Price * selectedQuantity
+    : commercialOffer.Price
+
   const { taxPercentage } = commercialOffer
   const sellingPriceWithTax =
     sellingPriceValue + sellingPriceValue * taxPercentage

--- a/react/components/InstallmentsRenderer.tsx
+++ b/react/components/InstallmentsRenderer.tsx
@@ -18,10 +18,17 @@ const CSS_HANDLES = [
 
 interface Props extends BasicPriceProps {
   installments: Partial<ProductTypes.Installment>
+  selectedQuantity?: number
 }
 
 function InstallmentsRenderer(props: Props) {
-  const { message, markers, installments } = props
+  const {
+    message,
+    markers,
+    installments,
+    multiplyQuantity = false,
+    selectedQuantity = 1,
+  } = props
   const handles = useCssHandles(CSS_HANDLES)
 
   const {
@@ -31,6 +38,9 @@ function InstallmentsRenderer(props: Props) {
     PaymentSystemName,
     TotalValuePlusInterestRate,
   } = installments
+
+  const installmentValue =
+    multiplyQuantity && Value ? Value * selectedQuantity : Value
 
   const hasInterest = InterestRate !== 0
 
@@ -53,7 +63,7 @@ function InstallmentsRenderer(props: Props) {
           ),
           installmentValue: (
             <span key="installmentValue" className={handles.installmentValue}>
-              <FormattedCurrency value={Value} />
+              <FormattedCurrency value={installmentValue} />
             </span>
           ),
           installmentsTotalValue: (

--- a/react/components/InstallmentsRenderer.tsx
+++ b/react/components/InstallmentsRenderer.tsx
@@ -26,7 +26,7 @@ function InstallmentsRenderer(props: Props) {
     message,
     markers,
     installments,
-    multiplyQuantity = false,
+    multiplyBySelectedQuantity = false,
     selectedQuantity = 1,
   } = props
   const handles = useCssHandles(CSS_HANDLES)
@@ -40,7 +40,7 @@ function InstallmentsRenderer(props: Props) {
   } = installments
 
   const installmentValue =
-    multiplyQuantity && Value ? Value * selectedQuantity : Value
+    multiplyBySelectedQuantity && Value ? Value * selectedQuantity : Value
 
   const hasInterest = InterestRate !== 0
 

--- a/react/package.json
+++ b/react/package.json
@@ -21,7 +21,7 @@
     "@vtex/tsconfig": "^0.2.0",
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.5.8",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",

--- a/react/types/index.ts
+++ b/react/types/index.ts
@@ -3,6 +3,7 @@ import { FC } from 'react'
 export interface BasicPriceProps {
   message: string
   markers: string[]
+  multiplyQuantity?: boolean
 }
 
 export interface PriceRangeProps {

--- a/react/types/index.ts
+++ b/react/types/index.ts
@@ -3,7 +3,7 @@ import { FC } from 'react'
 export interface BasicPriceProps {
   message: string
   markers: string[]
-  multiplyQuantity?: boolean
+  multiplyBySelectedQuantity?: boolean
 }
 
 export interface PriceRangeProps {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4750,12 +4750,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.7.3:
+typescript@3.9.7, typescript@^3.7.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
#### What problem is this solving?

- Displays information multiplied by `selectedQuantity` product context prop.

*Ideally this feature would integrate with the Promotions and Taxes module to accurately display the price. I've included a warning in the prop description.*

#### How to test it?

##### Shelf
- Open [Workspace](https://juliomoreira--drinkrunnr.myvtex.com)
- Scroll until you see a row of products;
- Use the quantity selector;
- Observe that the price updates accordingly;

##### Product
- Open [Workspace](https://juliomoreira--drinkrunnr.myvtex.com/cebdf7ec-861c-4bcc-93f0-ce4af7d4c02f/p)
- Navigate to a product eg.: [Example Product](https://juliomoreira--drinkrunnr.myvtex.com/cebdf7ec-861c-4bcc-93f0-ce4af7d4c02f/p)
- Use the quantity selector;
- Observe that the price updates accordingly;

#### Screenshots or example usage:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/1207017/95995649-2a788200-0e08-11eb-8e59-06ad1d0b8e6e.gif)

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/1207017/95995722-42500600-0e08-11eb-9d49-b5ec3af86153.gif)

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/MF9wHplBBbqwYiTTEk/giphy.gif)
