### PR TITLE
compactMode prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `compactMode` prop on `product-price-savings`
 
 ## [1.9.0] - 2020-09-22
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,12 +73,6 @@ Every block in this app only has three props in common:
 |  `blockClass`  |  `string`  |  Block  ID  of your choosing to  be  used  in [CSS  customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization#using-the-blockclass-property).  |  `undefined`  |
 |  `message`  |  `string`  |  Defines the block's default text i.e. the block message. You can also define which text message a block will render on the UI using the admin's Site Editor.  |  `undefined`  |
 
-The `product-price-savings` block, in turn, also has following prop (in addition to the 3 props stated above):
-
-| Prop name          | Type      |  Description | Default value |
-| --------------------| ----------|--------------|---------------|
-| `compactMode` | `boolean` | Whether the white space between the number and the percent sign should be removed from the UI (`true`) or not (`false`). | `false` | 
-
 For example:
 
 ```json

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,12 @@ Every block in this app only has three props in common:
 |  `blockClass`  |  `string`  |  Block  ID  of your choosing to  be  used  in [CSS  customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization#using-the-blockclass-property).  |  `undefined`  |
 |  `message`  |  `string`  |  Defines the block's default text i.e. the block message. You can also define which text message a block will render on the UI using the admin's Site Editor.  |  `undefined`  |
 
+The `product-price-savings` block, in turn, also has following prop (in addition to the 3 props stated above):
+
+| Prop name          | Type      |  Description | Default value |
+| --------------------| ----------|--------------|---------------|
+| `compactMode` | `boolean` | Whether the white space between the number and the percent sign should be removed from the UI (`true`) or not (`false`). | `false` | 
+
 For example:
 
 ```json

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,6 +145,7 @@ In addition to that, keep in mind the message variables for each block since you
 | `savingsValue` | `string` | Difference between previous product price and the new one. |
 | `savingsWithTax` | `string` | Difference between previous product price and the new one with taxes. |
 | `savingsPercentage` | `string` | Percentage of savings. |
+| `compactMode` | `boolean` | Set to `true` if you want to remove the white space between the number and the percent sign. Default value: `false` |
 
 - **`product-spot-price-savings`**
 

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -6,7 +6,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
 
-import { StorefrontFC, BasicPriceProps } from './types'
+import { StorefrontFC, BasicPriceProps, SavingsProps } from './types'
 
 const CSS_HANDLES = [
   'savings',
@@ -17,8 +17,12 @@ const CSS_HANDLES = [
   'savingsPercentage',
 ] as const
 
-const Savings: StorefrontFC<BasicPriceProps> = props => {
-  const { message, markers } = props
+const Savings: StorefrontFC<BasicPriceProps & SavingsProps> = props => {
+  const { message, markers, compactMode } = props
+  const compacted = !!(
+    typeof compactMode !== 'undefined' && compactMode === true
+  )
+
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
   const productSummaryValue = useProductSummary()
@@ -78,7 +82,13 @@ const Savings: StorefrontFC<BasicPriceProps> = props => {
           ),
           savingsPercentage: (
             <span key="savingsPercentage" className={handles.savingsPercentage}>
-              <FormattedNumber value={savingsPercentage} style="percent" />
+              {compacted ? (
+                <span>
+                  <FormattedNumber value={savingsPercentage * 100} />%
+                </span>
+              ) : (
+                <FormattedNumber value={savingsPercentage} style="percent" />
+              )}
             </span>
           ),
         }}

--- a/react/package.json
+++ b/react/package.json
@@ -21,7 +21,7 @@
     "@vtex/tsconfig": "^0.2.0",
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.5.8",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",

--- a/react/types/index.ts
+++ b/react/types/index.ts
@@ -5,6 +5,10 @@ export interface BasicPriceProps {
   markers: string[]
 }
 
+export interface SavingsProps {
+  compactMode: boolean
+}
+
 export interface PriceRangeProps {
   message: string
   noRangeMessage: string

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4750,12 +4750,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.7.3:
+typescript@3.9.7, typescript@^3.7.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
#### What problem is this solving?
- Added `compactMode` prop on `product-price-savings`. 

#### How to test it?

[Workspace](https://longo--distinctive.myvtex.com/ceas-femei-crystalline-oval-ls-wht-wht-pro-placat-cu-aur-roz-2000005-5230946/p)

It's enabled on the product image

#### Screenshots or example usage:

```jsonc
"product-price-savings#product": {
    "props": {
      "message": "-{savingsPercentage}",
      "compactMode": true
    }
  },
```
