### PR TITLE
Use first available seller instead of always using the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use the first available seller data.
 
 ## [1.10.0] - 2020-11-05
 ### Added

--- a/react/Installments.tsx
+++ b/react/Installments.tsx
@@ -4,12 +4,16 @@ import { useProduct, ProductTypes } from 'vtex.product-context'
 
 import { StorefrontFC, BasicPriceProps } from './types'
 import InstallmentsRenderer from './components/InstallmentsRenderer'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const Installments: StorefrontFC<BasicPriceProps> = props => {
   const { message, markers } = props
   const productContextValue = useProduct()
-  const commercialOffer =
-    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const availableSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
+
+  const commercialOffer = availableSeller?.commertialOffer
 
   if (
     !commercialOffer?.Installments ||

--- a/react/InstallmentsList.tsx
+++ b/react/InstallmentsList.tsx
@@ -7,6 +7,7 @@ import {
   InstallmentsContextProvider,
 } from './components/InstallmentsContext'
 import pickInstallments from './modules/pickInstallments'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const CSS_HANDLES = ['installmentsListContainer'] as const
 
@@ -19,8 +20,11 @@ function InstallmentsList(props: Props) {
   const productContextValue = useProduct()
   const handles = useCssHandles(CSS_HANDLES)
 
-  const commercialOffer =
-    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const availableSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
+
+  const commercialOffer = availableSeller?.commertialOffer
 
   if (
     !commercialOffer?.Installments ||

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -6,6 +6,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { StorefrontFC, BasicPriceProps } from './types'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const CSS_HANDLES = [
   'listPrice',
@@ -19,8 +20,11 @@ const ListPrice: StorefrontFC<BasicPriceProps> = props => {
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
 
-  const commercialOffer =
-    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const availableSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
+
+  const commercialOffer = availableSeller?.commertialOffer
 
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null

--- a/react/ListPriceRange.tsx
+++ b/react/ListPriceRange.tsx
@@ -6,6 +6,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { StorefrontFC, PriceRangeProps } from './types'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const CSS_HANDLES = [
   'listPriceRange',
@@ -35,8 +36,11 @@ const ListPriceRange: StorefrontFC<PriceRangeProps> = props => {
     return null
   }
 
-  const commercialOffer =
-    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const availableSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
+
+  const commercialOffer = availableSeller?.commertialOffer
 
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null

--- a/react/PriceSuspense.tsx
+++ b/react/PriceSuspense.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useCssHandles } from 'vtex.css-handles'
-import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
+import { ProductSummaryContext } from 'vtex.product-summary-context'
 import classNames from 'classnames'
 
 import PriceLoadingSpinner from './components/PriceLoadingSpinner'
@@ -20,7 +20,7 @@ const PriceSuspense: StorefrontFC<PriceSuspenseProps> = ({
   children,
   Fallback,
 }) => {
-  const { isPriceLoading } = useProductSummary()
+  const { isPriceLoading } = ProductSummaryContext.useProductSummary()
   const handles = useCssHandles(CSS_HANDLES)
 
   const contentWrapperClasses = classNames(

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -4,9 +4,10 @@ import { useProduct } from 'vtex.product-context'
 import { FormattedCurrency } from 'vtex.format-currency'
 import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
-import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
+import { ProductSummaryContext } from 'vtex.product-summary-context'
 
 import { StorefrontFC, BasicPriceProps } from './types'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const CSS_HANDLES = [
   'savings',
@@ -21,10 +22,13 @@ const Savings: StorefrontFC<BasicPriceProps> = props => {
   const { message, markers } = props
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
-  const productSummaryValue = useProductSummary()
+  const productSummaryValue = ProductSummaryContext.useProductSummary()
 
-  const commercialOffer =
-    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const availableSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
+
+  const commercialOffer = availableSeller?.commertialOffer
 
   if (
     !commercialOffer ||

--- a/react/SellerName.tsx
+++ b/react/SellerName.tsx
@@ -5,6 +5,7 @@ import { useProduct } from 'vtex.product-context'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import { StorefrontFC, BasicPriceProps } from './types'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const CSS_HANDLES = ['sellerNameContainer', 'sellerName'] as const
 
@@ -15,7 +16,9 @@ const ProductSellerName: StorefrontFC<Partial<BasicPriceProps>> = ({
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
 
-  const productSeller = productContextValue?.selectedItem?.sellers[0]
+  const productSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
 
   if (!productSeller) {
     return null

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -6,6 +6,7 @@ import { IOMessageWithMarkers } from 'vtex.native-types'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import { StorefrontFC, BasicPriceProps } from './types'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const CSS_HANDLES = [
   'sellingPrice',
@@ -19,8 +20,11 @@ const SellingPrice: StorefrontFC<BasicPriceProps> = props => {
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
 
-  const commercialOffer =
-    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const availableSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
+
+  const commercialOffer = availableSeller?.commertialOffer
 
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null

--- a/react/SellingPriceRange.tsx
+++ b/react/SellingPriceRange.tsx
@@ -6,6 +6,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { StorefrontFC, PriceRangeProps } from './types'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const CSS_HANDLES = [
   'sellingPriceRange',
@@ -28,8 +29,11 @@ const SellingPriceRange: StorefrontFC<PriceRangeProps> = props => {
     return null
   }
 
-  const commercialOffer =
-    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const availableSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
+
+  const commercialOffer = availableSeller?.commertialOffer
 
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null

--- a/react/SpotPrice.tsx
+++ b/react/SpotPrice.tsx
@@ -6,6 +6,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { StorefrontFC, BasicPriceProps } from './types'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const CSS_HANDLES = ['spotPrice', 'spotPriceValue'] as const
 
@@ -14,8 +15,11 @@ const SpotPrice: StorefrontFC<BasicPriceProps> = props => {
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
 
-  const commercialOffer =
-    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const availableSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
+
+  const commercialOffer = availableSeller?.commertialOffer
 
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null

--- a/react/SpotPriceSavings.tsx
+++ b/react/SpotPriceSavings.tsx
@@ -6,6 +6,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { StorefrontFC, BasicPriceProps } from './types'
+import { getFirstAvailableSeller } from './modules/seller'
 
 const CSS_HANDLES = [
   'spotPriceSavings',
@@ -21,8 +22,11 @@ const SpotPriceSavings: StorefrontFC<BasicPriceProps> = props => {
   const handles = useCssHandles(CSS_HANDLES)
   const productContextValue = useProduct()
 
-  const commercialOffer =
-    productContextValue?.selectedItem?.sellers[0]?.commertialOffer
+  const availableSeller = getFirstAvailableSeller(
+    productContextValue?.selectedItem?.sellers
+  )
+
+  const commercialOffer = availableSeller?.commertialOffer
 
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null

--- a/react/modules/seller.ts
+++ b/react/modules/seller.ts
@@ -1,0 +1,13 @@
+import { ProductTypes } from 'vtex.product-context'
+
+export function getFirstAvailableSeller(sellers?: ProductTypes.Seller[]) {
+  if (!sellers || sellers.length === 0) {
+    return
+  }
+
+  const availableSeller = sellers.find(
+    seller => seller.commertialOffer.AvailableQuantity !== 0
+  )
+
+  return availableSeller
+}

--- a/react/package.json
+++ b/react/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.1.3",
+    "@types/classnames": "^2.2.11",
     "@types/graphql": "^14.5.0",
     "@types/jest": "^24.9.0",
     "@types/node": "^13.1.8",
@@ -23,10 +24,11 @@
     "graphql": "^14.5.8",
     "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
-    "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency",
-    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
-    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.2/public/@types/vtex.product-context",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime"
+    "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.2.0/public/@types/vtex.format-currency",
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.3/public/@types/vtex.native-types",
+    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.2/public/@types/vtex.product-context",
+    "vtex.product-summary-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.6.0/public/@types/vtex.product-summary-context",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.125.0/public/@types/vtex.render-runtime"
   },
   "version": "1.10.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1322,6 +1322,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/classnames@^2.2.11":
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.11.tgz#2521cc86f69d15c5b90664e4829d84566052c1cf"
+  integrity sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -4854,21 +4859,25 @@ verror@1.10.0:
   version "0.4.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
 
-"vtex.format-currency@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency":
-  version "0.1.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency#a36aa61ff95701388c0c793b8a7539b0c3d9dcf3"
+"vtex.format-currency@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.2.0/public/@types/vtex.format-currency":
+  version "0.2.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.2.0/public/@types/vtex.format-currency#764e70df27af6a2e2b2a828c5870a5008b5ef28e"
 
-"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types":
-  version "0.7.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.3/public/@types/vtex.native-types":
+  version "0.7.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.3/public/@types/vtex.native-types#8b32238685324687995052e8c746449bcc00985c"
 
-"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.2/public/@types/vtex.product-context":
-  version "0.8.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.2/public/@types/vtex.product-context#e149c4f680faf1bfdc2b30a136f6597bf9ef37b7"
+"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.2/public/@types/vtex.product-context":
+  version "0.9.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.2/public/@types/vtex.product-context#f4387e4b4ec59cf7e63b8f68202426a279693dd1"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime":
-  version "8.112.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.112.0/public/@types/vtex.render-runtime#d24f7d970497a80e1e38864db09bbe5da61e0696"
+"vtex.product-summary-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.6.0/public/@types/vtex.product-summary-context":
+  version "0.6.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.6.0/public/@types/vtex.product-summary-context#653154fe985a37b0e030b7b729f77a7ca33c02c4"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.125.0/public/@types/vtex.render-runtime":
+  version "8.125.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.125.0/public/@types/vtex.render-runtime#9cef678d3abf4e84c6aeabf266530882a3a3cfd7"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
#### What problem is this solving?

Fix issue where the components was always using the first seller. The first seller could have items unavailable and without price, leading to rendering nothing.

This PR changes to get the first available seller instead.

#### How to test it?

https://brenovtex--motorolauk.myvtex.com/

#### Screenshots or example usage:

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/101959001-3ce22280-3be3-11eb-8719-6299c70da02e.png) | ![image](https://user-images.githubusercontent.com/284515/101959041-55ead380-3be3-11eb-9a10-81409f1c0eed.png)

#### Describe alternatives you've considered, if any.

For future unit tests, this is object of sellers of the item:

```json
{
  "sellers": [
    {
      "sellerId": "motorolaeudr",
      "sellerName": "Motorola DR",
      "commertialOffer": {
        "discountHighlights": [],
        "teasers": [],
        "Price": 0,
        "ListPrice": 0,
        "Tax": 0,
        "taxPercentage": null,
        "spotPrice": 0,
        "PriceWithoutDiscount": 0,
        "RewardValue": 0,
        "PriceValidUntil": "2020-12-21T10:30:00Z",
        "AvailableQuantity": 0,
        "Installments": [
          {
            "Value": 179.99,
            "InterestRate": 0,
            "TotalValuePlusInterestRate": 179.99,
            "NumberOfInstallments": 1,
            "Name": "",
            "PaymentSystemName": "",
            "__typename": "Installment"
          }
        ],
        "__typename": "Offer"
      },
      "__typename": "Seller"
    },
    {
      "sellerId": "motorolaeu",
      "sellerName": "Motorola EU",
      "commertialOffer": {
        "discountHighlights": [],
        "teasers": [],
        "Price": 179.99,
        "ListPrice": 239.99,
        "Tax": 0,
        "taxPercentage": 0,
        "spotPrice": 179.99,
        "PriceWithoutDiscount": 239.99,
        "RewardValue": 0,
        "PriceValidUntil": "2020-12-21T10:30:00Z",
        "AvailableQuantity": 10000,
        "Installments": [
          {
            "Value": 179.99,
            "InterestRate": 0,
            "TotalValuePlusInterestRate": 179.99,
            "NumberOfInstallments": 1,
            "Name": "",
            "PaymentSystemName": "",
            "__typename": "Installment"
          }
        ],
        "__typename": "Offer"
      },
      "__typename": "Seller"
    },
    {
      "sellerId": "1",
      "sellerName": "Motorola.co.uk",
      "commertialOffer": {
        "discountHighlights": [],
        "teasers": [],
        "Price": 0,
        "ListPrice": 0,
        "Tax": 0,
        "taxPercentage": null,
        "spotPrice": 0,
        "PriceWithoutDiscount": 0,
        "RewardValue": 0,
        "PriceValidUntil": null,
        "AvailableQuantity": 0,
        "Installments": [
          {
            "Value": 179.99,
            "InterestRate": 0,
            "TotalValuePlusInterestRate": 179.99,
            "NumberOfInstallments": 1,
            "Name": "",
            "PaymentSystemName": "",
            "__typename": "Installment"
          }
        ],
        "__typename": "Offer"
      },
      "__typename": "Seller"
    }
  ]
}
```

#### Related to / Depends on

n/a

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
