### PR TITLE
add selling-price-range missing components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Add `sellingPriceValue` and `sellingPriceWithTax` to "product-selling-price-range" block
+
 ## [1.10.1] - 2020-12-14
 ### Fixed
 - Use the first available seller data.

--- a/react/SellingPriceRange.tsx
+++ b/react/SellingPriceRange.tsx
@@ -14,6 +14,8 @@ const CSS_HANDLES = [
   'sellingPriceRangeMinWithTax',
   'sellingPriceRangeMaxValue',
   'sellingPriceRangeMaxWithTax',
+  'sellingPriceRangeValue',
+  'sellingPriceRangeWithTax',
   'sellingPriceRangeUniqueValue',
   'sellingPriceRangeUniqueWithTax',
 ] as const
@@ -44,6 +46,9 @@ const SellingPriceRange: StorefrontFC<PriceRangeProps> = props => {
   const hasRange = minPrice !== maxPrice
   const minPriceWithTax = minPrice + minPrice * commercialOffer.taxPercentage
   const maxPriceWithTax = maxPrice + maxPrice * commercialOffer.taxPercentage
+  const sellingPrice = commercialOffer.PriceWithoutDiscount
+  const sellingPriceWithTax = commercialOffer.PriceWithoutDiscount + commercialOffer.PriceWithoutDiscount * commercialOffer.taxPercentage
+
 
   if (hasRange) {
     return (
@@ -83,6 +88,22 @@ const SellingPriceRange: StorefrontFC<PriceRangeProps> = props => {
                 className={handles.sellingPriceRangeMaxWithTax}
               >
                 <FormattedCurrency value={maxPriceWithTax} />
+              </span>
+            ),
+            sellingPriceValue: (
+              <span
+                key="sellingPriceValue"
+                className={handles.sellingPriceRangeValue}
+              >
+                <FormattedCurrency value={sellingPrice} />
+              </span>
+            ),
+            sellingPriceWithTax: (
+              <span
+                key="sellingPriceWithTax"
+                className={handles.sellingPriceRangeValue}
+              >
+                <FormattedCurrency value={sellingPriceWithTax} />
               </span>
             ),
           }}

--- a/react/SellingPriceRange.tsx
+++ b/react/SellingPriceRange.tsx
@@ -101,7 +101,7 @@ const SellingPriceRange: StorefrontFC<PriceRangeProps> = props => {
             sellingPriceWithTax: (
               <span
                 key="sellingPriceWithTax"
-                className={handles.sellingPriceRangeValue}
+                className={handles.sellingPriceRangeWithTax}
               >
                 <FormattedCurrency value={sellingPriceWithTax} />
               </span>


### PR DESCRIPTION
#### What problem is this solving?

Includes the 2 missing blocks "sellingPriceValue" and "sellingPriceWithTax" of variations in `product-selling-price-range` 

#### How to test it?

sellingPriceValue and sellingPriceWithTax on the right side.

https://productpriceapp--sandboxusdev.myvtex.com/invicta-lupah-swiss-movement-quartz-watch---stainless-steel-case---model-0010/p?skuId=10

#### Screenshots or example usage:

<img src="https://i.ibb.co/Xp01yYF/sellpingpricerange.jpg" alt="sellpingpricerange" border="0">

#### Related to / Depends on

https://vtexhelp.zendesk.com/agent/tickets/299388
Issue #49 

#### How does this PR make you feel? [:link:](http://giphy.com/)

<img src="https://media.giphy.com/media/11sBLVxNs7v6WA/giphy.gif" alt="sellpingpricerange" border="0">