### PR TITLE
Added taxValue prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `taxValue` on `product-selling-price` and `product-list-price`
+
 ## [1.12.0] - 2021-01-06
 ### Added
 - Support for custom classes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -149,6 +149,7 @@ In addition to that, keep in mind the message variables for each block since you
 | `listPriceValue` | `string` | List price value. |
 | `listPriceWithTax` | `string` | List price value with tax. |
 | `taxPercentage` | `string` | Tax percentage. |
+| `taxValue` | `string` | Tax value. |
 
 - **`product-selling-price`**
 
@@ -158,6 +159,7 @@ In addition to that, keep in mind the message variables for each block since you
 | `sellingPriceWithTax` | `string` | Selling price with tax. |
 | `taxPercentage` | `string` | Tax percentage. |
 | `hasListPrice` | `boolean` | Whether the product has a list price (`true`) or not (`false`). |
+| `taxValue` | `string` | Tax value. |
 
 - **`product-spot-price`**
 

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -12,6 +12,7 @@ const CSS_HANDLES = [
   'listPriceValue',
   'listPriceWithTax',
   'taxPercentage',
+  'taxValue'
 ] as const
 
 const messages = defineMessages({
@@ -55,6 +56,7 @@ function ListPrice({
   const sellingPriceValue = commercialOffer.Price
   const { taxPercentage } = commercialOffer
   const listPriceWithTax = listPriceValue + listPriceValue * taxPercentage
+  const taxValue = commercialOffer.Tax
 
   if (listPriceValue <= sellingPriceValue) {
     return null
@@ -86,6 +88,11 @@ function ListPrice({
           taxPercentage: (
             <span key="taxPercentage" className={handles.taxPercentage}>
               <FormattedNumber value={taxPercentage} style="percent" />
+            </span>
+          ),
+          taxValue: (
+            <span key="taxValue" className={handles.taxValue}>
+              <FormattedCurrency value={taxValue} />
             </span>
           ),
         }}

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -12,6 +12,7 @@ const CSS_HANDLES = [
   'sellingPriceValue',
   'sellingPriceWithTax',
   'taxPercentage',
+  'taxValue'
 ] as const
 
 const messages = defineMessages({
@@ -56,6 +57,7 @@ function SellingPrice({
   const { taxPercentage } = commercialOffer
   const sellingPriceWithTax =
     sellingPriceValue + sellingPriceValue * taxPercentage
+  const taxValue = commercialOffer.Tax
 
   const hasListPrice = sellingPriceValue !== listPriceValue
 
@@ -87,6 +89,11 @@ function SellingPrice({
           taxPercentage: (
             <span key="taxPercentage" className={handles.taxPercentage}>
               <FormattedNumber value={taxPercentage} style="percent" />
+            </span>
+          ),
+          taxValue: (
+            <span key="taxValue" className={handles.taxValue}>
+              <FormattedCurrency value={taxValue} />
             </span>
           ),
           hasListPrice,


### PR DESCRIPTION
#### What problem is this solving?

Adding taxValue prop to show the value of the tax for when a client requests that instead of the percentage or alongside the percentage.

#### How to test it?

[Workspace](https://razvan--vetrob2c.myvtex.com/felibio-pch-r1-doza-2932/p) - need to be logged in to see the tax

#### Screenshots or example usage:

I replaced the taxPercentage message prop with taxValue to show the change in this case:

Before:
![image](https://user-images.githubusercontent.com/71461884/103777027-fb556380-5038-11eb-9b95-51b6f629a3a0.png)

After:
![image](https://user-images.githubusercontent.com/71461884/103775998-7f0e5080-5037-11eb-8046-dd766d8a0c0a.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/62PP2yEIAZF6g/giphy.gif)
