### PR TITLE
Adding percentageStyle to product-price-savings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `percentageStyle` on `product-price-savings`
 
 ## [1.13.0] - 2021-02-04
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,13 @@ For example:
 },
 ```
 
+The block `product-price-savings` has an additional prop:
+
+| Prop name          | Type      |  Description | Default value |
+| --------------------| ----------|--------------|---------------|
+| `percentageStyle` | `locale` or `compact` | Set to `compact` if you want to remove the white space between the number and the percent sign. It uses pattern provided by the current locale as default. | `locale` |
+
+
 If you are using the asynchronous price feature, you can take advantage of the `product-price-suspense` and its props:
 
 | Prop name    | Type       | Description                                              | Default value       |


### PR DESCRIPTION
#### What problem is this solving?
This PR adds the ability to remove the space that may appear between the numbers and the percentage sign present on the `product-price-savings` block. This happened when, by default, the definitions of a locale made react-intl insert a space between these elements. An example of this is the `ro-RO` locale.

#### How to test it?

Before the change:
[Workspace](https://distinctive.myvtex.com/ceas-femei-crystalline-oval-ls-wht-wht-pro-placat-cu-aur-roz-2000005-5230946/p)

After the change:
[Workspace](https://icarovtex--distinctive.myvtex.com/ceas-femei-crystalline-oval-ls-wht-wht-pro-placat-cu-aur-roz-2000005-5230946/p)

Ensuring it's backwards compatible (look at the percentages at the shelf):
[Workspace](https://icarovtex2--storecomponents.myvtex.com)

#### Screenshots or example usage:

<img width="282" alt="Screen Shot 2021-02-24 at 17 39 40" src="https://user-images.githubusercontent.com/8127610/109062900-4863c680-76c7-11eb-977a-d6a7ad641698.png">

#### Related to / Depends on

This PR is an evolution based on the idea first submitted on [this PR](https://github.com/vtex-apps/product-price/pull/50). @khrizzcristian will be added as a contributor :)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/jtpDVh0B6NKV04pUCA/giphy-downsized.gif)
