### PR TITLE
FeatureUnitMultiplierAndMeasurementUnit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- `measurementUnit` text and `unitMultiplier` logic at `product-selling-price` and `product-list-price`.
 
 ## [1.15.0] - 2021-03-09
 ### Added
-- `percentageStyle` on `product-price-savings`
+- `percentageStyle` on `product-price-savings`.
 
 ## [1.14.0] - 2021-03-08
 
@@ -21,12 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.13.1] - 2021-03-08
 
 ### Fixed
-- Updated documentation (removed link to internal doc)
+- Updated documentation (removed link to internal doc).
 
 ## [1.13.0] - 2021-02-04
 
 ### Added
-- `taxValue` on `product-selling-price` and `product-list-price`
+- `taxValue` on `product-selling-price` and `product-list-price`.
 
 ## [1.12.0] - 2021-01-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
-- `measurementUnit` and `hasMeasurementUnit` variables to `product-selling-price`.
+- `measurementUnit`, `hasMeasurementUnit`, `unitMultiplier`, and `hasUnitMultiplier` variables to `product-selling-price`.
 
 ### Fixed
 
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Now `product-selling-price` default message shows the measurement unit if available.
+- Now `product-selling-price` default message shows the measurement unit and unit multiplier if available.
 
 ## [1.15.0] - 2021-03-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
-- `measurementUnit` text and `unitMultiplier` logic at `product-selling-price` and `product-list-price`.
+- `measurementUnit` and `hasMeasurementUnit` variables to `product-selling-price`.
+
+### Fixed
+
+- Take `unitMultiplier` into account in price logic at `product-selling-price`.
+
+### Changed
+
+- Now `product-selling-price` default message shows the measurement unit if available.
 
 ## [1.15.0] - 2021-03-09
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -157,7 +157,6 @@ In addition to that, keep in mind the message variables for each block since you
 | `listPriceWithTax` | `string` | List price value with tax. |
 | `taxPercentage` | `string` | Tax percentage. |
 | `taxValue` | `string` | Tax value. |
-| `measurementUnit` | `string` | Measure unit text. |
 
 - **`product-selling-price`**
 
@@ -168,6 +167,7 @@ In addition to that, keep in mind the message variables for each block since you
 | `taxPercentage` | `string` | Tax percentage. |
 | `hasListPrice` | `boolean` | Whether the product has a list price (`true`) or not (`false`). |
 | `taxValue` | `string` | Tax value. |
+| `hasMeasurementUnit` | `boolean` | Whether the product has a measurement unit (`true`) or not (`false`). |
 | `measurementUnit` | `string` | Measure unit text. |
 
 - **`product-spot-price`**

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,6 +169,8 @@ In addition to that, keep in mind the message variables for each block since you
 | `taxValue` | `string` | Tax value. |
 | `hasMeasurementUnit` | `boolean` | Whether the product has a measurement unit (`true`) or not (`false`). |
 | `measurementUnit` | `string` | Measure unit text. |
+| `hasUnitMultiplier` | `booean` | Whether the product has a unit multiplier different than 1 (`true`) or not (`false`). |
+| `unitMultiplier` | `string` | Value of the unit multiplier. |
 
 - **`product-spot-price`**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,7 +169,7 @@ In addition to that, keep in mind the message variables for each block since you
 | `taxValue` | `string` | Tax value. |
 | `hasMeasurementUnit` | `boolean` | Whether the product has a measurement unit (`true`) or not (`false`). |
 | `measurementUnit` | `string` | Measure unit text. |
-| `hasUnitMultiplier` | `booean` | Whether the product has a unit multiplier different than 1 (`true`) or not (`false`). |
+| `hasUnitMultiplier` | `boolean` | Whether the product has a unit multiplier different than 1 (`true`) or not (`false`). |
 | `unitMultiplier` | `string` | Value of the unit multiplier. |
 
 - **`product-spot-price`**

--- a/docs/README.md
+++ b/docs/README.md
@@ -157,6 +157,7 @@ In addition to that, keep in mind the message variables for each block since you
 | `listPriceWithTax` | `string` | List price value with tax. |
 | `taxPercentage` | `string` | Tax percentage. |
 | `taxValue` | `string` | Tax value. |
+| `measurementUnit` | `string` | Measure unit text. |
 
 - **`product-selling-price`**
 
@@ -167,6 +168,7 @@ In addition to that, keep in mind the message variables for each block since you
 | `taxPercentage` | `string` | Tax percentage. |
 | `hasListPrice` | `boolean` | Whether the product has a list price (`true`) or not (`false`). |
 | `taxValue` | `string` | Tax value. |
+| `measurementUnit` | `string` | Measure unit text. |
 
 - **`product-spot-price`**
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,6 @@
 {
   "store/list-price.default": "{listPriceValue}",
-  "store/selling-price.default": "{sellingPriceValue}",
+  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {measurementUnit}} false {}}",
   "store/spot-price.default": "Spot price: {spotPriceValue}",
   "store/spot-price-savings.default": "Spot price savings: {spotPriceSavingsValue}",
   "store/savings.default": "Save {savingsValue}",
@@ -14,7 +14,7 @@
   "admin/list-price.title": "List Price",
   "admin/seller-name.title": "Seller Name",
   "admin/seller-name.description": "Values available for interpolation: '{sellerName}'",
-  "admin/selling-price.description": "Values available for interpolation: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}'",
+  "admin/selling-price.description": "Values available for interpolation: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}, {hasMeasurementUnit}, {measurementUnit}'",
   "admin/selling-price.title": "Selling Price",
   "admin/spot-price.description": "Values available for interpolation: '{spotPrice}'",
   "admin/spot-price.title": "Spot Price",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,6 @@
 {
   "store/list-price.default": "{listPriceValue}",
-  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {measurementUnit}} false {}}",
+  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {hasUnitMultiplier, select, true {{unitMultiplier}} false {}} {measurementUnit}} false {}}",
   "store/spot-price.default": "Spot price: {spotPriceValue}",
   "store/spot-price-savings.default": "Spot price savings: {spotPriceSavingsValue}",
   "store/savings.default": "Save {savingsValue}",
@@ -14,7 +14,7 @@
   "admin/list-price.title": "List Price",
   "admin/seller-name.title": "Seller Name",
   "admin/seller-name.description": "Values available for interpolation: '{sellerName}'",
-  "admin/selling-price.description": "Values available for interpolation: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}, {hasMeasurementUnit}, {measurementUnit}'",
+  "admin/selling-price.description": "Values available for interpolation: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}, {hasMeasurementUnit}, {measurementUnit}, {hasUnitMultiplier}, {unitMultiplier}'",
   "admin/selling-price.title": "Selling Price",
   "admin/spot-price.description": "Values available for interpolation: '{spotPrice}'",
   "admin/spot-price.title": "Spot Price",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,6 +1,6 @@
 {
   "store/list-price.default": "{listPriceValue}",
-  "store/selling-price.default": "{sellingPriceValue}",
+  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {measurementUnit}} false {}}",
   "store/spot-price.default": "Precio en efectivo: {spotPriceValue}",
   "store/spot-price-savings.default": "Shorro de precio en efectivo: {spotPriceSavingsValue}",
   "store/savings.default": "Ahorre {savingsValue}",
@@ -14,7 +14,7 @@
   "admin/list-price.title": "Precio de Lista",
   "admin/seller-name.title": "Nombre del vendedor",
   "admin/seller-name.description": "Valores disponibles para interpolación: '{sellerName}'",
-  "admin/selling-price.description": "Valores disponibles para interpolación: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}'",
+  "admin/selling-price.description": "Valores disponibles para interpolación: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}, {hasMeasurementUnit}, {measurementUnit}'",
   "admin/selling-price.title": "Precio de Venta",
   "admin/spot-price.description": "Valores disponibles para interpolación: '{spotPrice}'",
   "admin/spot-price.title": "Precio en Efectivo",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,6 +1,6 @@
 {
   "store/list-price.default": "{listPriceValue}",
-  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {measurementUnit}} false {}}",
+  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {hasUnitMultiplier, select, true {{unitMultiplier}} false {}} {measurementUnit}} false {}}",
   "store/spot-price.default": "Precio en efectivo: {spotPriceValue}",
   "store/spot-price-savings.default": "Shorro de precio en efectivo: {spotPriceSavingsValue}",
   "store/savings.default": "Ahorre {savingsValue}",
@@ -14,7 +14,7 @@
   "admin/list-price.title": "Precio de Lista",
   "admin/seller-name.title": "Nombre del vendedor",
   "admin/seller-name.description": "Valores disponibles para interpolación: '{sellerName}'",
-  "admin/selling-price.description": "Valores disponibles para interpolación: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}, {hasMeasurementUnit}, {measurementUnit}'",
+  "admin/selling-price.description": "Valores disponibles para interpolación: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}, {hasMeasurementUnit}, {measurementUnit}, {hasUnitMultiplier}, {unitMultiplier}'",
   "admin/selling-price.title": "Precio de Venta",
   "admin/spot-price.description": "Valores disponibles para interpolación: '{spotPrice}'",
   "admin/spot-price.title": "Precio en Efectivo",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,6 @@
 {
   "store/list-price.default": "{listPriceValue}",
-  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {measurementUnit}} false {}}",
+  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {hasUnitMultiplier, select, true {{unitMultiplier}} false {}} {measurementUnit}} false {}}",
   "store/spot-price.default": "Preço a vista: {spotPriceValue}",
   "store/spot-price-savings.default": "Economia de preço a vista: {spotPriceSavingsValue}",
   "store/savings.default": "Economize {savingsValue}",
@@ -14,7 +14,7 @@
   "admin/list-price.title": "Preço de Tabela",
   "admin/seller-name.title": "Nome do vendedor",
   "admin/seller-name.description": "Valores disponiveis para interpolação: '{sellerName}'",
-  "admin/selling-price.description": "Valores disponiveis para interpolação: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}, {hasMeasurementUnit}, {measurementUnit}'",
+  "admin/selling-price.description": "Valores disponiveis para interpolação: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}, {hasMeasurementUnit}, {measurementUnit}, {hasUnitMultiplier}, {unitMultiplier}'",
   "admin/selling-price.title": "Preço de Venda",
   "admin/spot-price.description": "Valores disponiveis para interpolação: '{spotPrice}'",
   "admin/spot-price.title": "Preço a Vista",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,6 @@
 {
   "store/list-price.default": "{listPriceValue}",
-  "store/selling-price.default": "{sellingPriceValue}",
+  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {measurementUnit}} false {}}",
   "store/spot-price.default": "Preço a vista: {spotPriceValue}",
   "store/spot-price-savings.default": "Economia de preço a vista: {spotPriceSavingsValue}",
   "store/savings.default": "Economize {savingsValue}",
@@ -14,7 +14,7 @@
   "admin/list-price.title": "Preço de Tabela",
   "admin/seller-name.title": "Nome do vendedor",
   "admin/seller-name.description": "Valores disponiveis para interpolação: '{sellerName}'",
-  "admin/selling-price.description": "Valores disponiveis para interpolação: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}'",
+  "admin/selling-price.description": "Valores disponiveis para interpolação: '{sellingPriceValue}, {sellingPriceWithTax}, {taxPercentage}, {hasListPrice}, {hasMeasurementUnit}, {measurementUnit}'",
   "admin/selling-price.title": "Preço de Venda",
   "admin/spot-price.description": "Valores disponiveis para interpolação: '{spotPrice}'",
   "admin/spot-price.title": "Preço a Vista",

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -12,7 +12,7 @@ const CSS_HANDLES = [
   'listPriceValue',
   'listPriceWithTax',
   'taxPercentage',
-  'taxValue'
+  'taxValue',
 ] as const
 
 const messages = defineMessages({

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -13,7 +13,7 @@ const CSS_HANDLES = [
   'sellingPriceWithTax',
   'taxPercentage',
   'taxValue',
-  'measurementUnit'
+  'measurementUnit',
 ] as const
 
 const messages = defineMessages({
@@ -40,7 +40,10 @@ function SellingPrice({
   markers = [],
   classes,
 }: Props) {
-  const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
+  const { handles, withModifiers } = useCssHandles(CSS_HANDLES, {
+    classes,
+  })
+
   const productContextValue = useProduct()
 
   const availableSeller = getFirstAvailableSeller(
@@ -52,22 +55,29 @@ function SellingPrice({
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null
   }
-  const measurementUnit = productContextValue?.selectedItem?.measurementUnit
-  const unitMultiplier = productContextValue?.selectedItem?.unitMultiplier
 
-  const sellingPriceValue: number = commercialOffer.Price * Number(unitMultiplier)
+  const measurementUnit =
+    productContextValue?.selectedItem?.measurementUnit ?? ''
+
+  const unitMultiplier = productContextValue?.selectedItem?.unitMultiplier ?? 1
+
+  const sellingPriceValue: number =
+    commercialOffer.Price * Number(unitMultiplier)
+
   const listPriceValue = commercialOffer.ListPrice * Number(unitMultiplier)
   const { taxPercentage } = commercialOffer
   const sellingPriceWithTax =
     sellingPriceValue + sellingPriceValue * taxPercentage
+
   const taxValue = commercialOffer.Tax
 
   const hasListPrice = sellingPriceValue !== listPriceValue
+  const hasMeasurementUnit = measurementUnit && measurementUnit !== 'un'
 
-  const containerClasses = withModifiers(
-    'sellingPrice',
-    hasListPrice ? 'hasListPrice' : ''
-  )
+  const containerClasses = withModifiers('sellingPrice', [
+    hasListPrice ? 'hasListPrice' : '',
+    hasMeasurementUnit ? 'hasMeasurementUnit' : '',
+  ])
 
   return (
     <span className={containerClasses}>
@@ -99,12 +109,13 @@ function SellingPrice({
               <FormattedCurrency value={taxValue} />
             </span>
           ),
+          hasMeasurementUnit,
+          hasListPrice,
           measurementUnit: (
             <span key="measurementUnit" className={handles.measurementUnit}>
-              {`/${measurementUnit}`}
+              {measurementUnit}
             </span>
           ),
-          hasListPrice,
         }}
       />
     </span>

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -12,7 +12,8 @@ const CSS_HANDLES = [
   'sellingPriceValue',
   'sellingPriceWithTax',
   'taxPercentage',
-  'taxValue'
+  'taxValue',
+  'measurementUnit'
 ] as const
 
 const messages = defineMessages({
@@ -51,9 +52,11 @@ function SellingPrice({
   if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
     return null
   }
+  const measurementUnit = productContextValue?.selectedItem?.measurementUnit
+  const unitMultiplier = productContextValue?.selectedItem?.unitMultiplier
 
-  const sellingPriceValue: number = commercialOffer.Price
-  const listPriceValue = commercialOffer.ListPrice
+  const sellingPriceValue: number = commercialOffer.Price * Number(unitMultiplier)
+  const listPriceValue = commercialOffer.ListPrice * Number(unitMultiplier)
   const { taxPercentage } = commercialOffer
   const sellingPriceWithTax =
     sellingPriceValue + sellingPriceValue * taxPercentage
@@ -94,6 +97,11 @@ function SellingPrice({
           taxValue: (
             <span key="taxValue" className={handles.taxValue}>
               <FormattedCurrency value={taxValue} />
+            </span>
+          ),
+          measurementUnit: (
+            <span key="measurementUnit" className={handles.measurementUnit}>
+              /{measurementUnit}
             </span>
           ),
           hasListPrice,

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -101,7 +101,7 @@ function SellingPrice({
           ),
           measurementUnit: (
             <span key="measurementUnit" className={handles.measurementUnit}>
-              /{measurementUnit}
+              {`/${measurementUnit}`}
             </span>
           ),
           hasListPrice,

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -14,6 +14,7 @@ const CSS_HANDLES = [
   'taxPercentage',
   'taxValue',
   'measurementUnit',
+  'unitMultiplier',
 ] as const
 
 const messages = defineMessages({
@@ -73,10 +74,12 @@ function SellingPrice({
 
   const hasListPrice = sellingPriceValue !== listPriceValue
   const hasMeasurementUnit = measurementUnit && measurementUnit !== 'un'
+  const hasUnitMultiplier = unitMultiplier !== 1
 
   const containerClasses = withModifiers('sellingPrice', [
     hasListPrice ? 'hasListPrice' : '',
     hasMeasurementUnit ? 'hasMeasurementUnit' : '',
+    hasUnitMultiplier ? 'hasUnitMultiplier' : '',
   ])
 
   return (
@@ -111,6 +114,12 @@ function SellingPrice({
           ),
           hasMeasurementUnit,
           hasListPrice,
+          hasUnitMultiplier,
+          unitMultiplier: (
+            <span key="unitMultiplier" className={handles.unitMultiplier}>
+              <FormattedNumber value={unitMultiplier} />
+            </span>
+          ),
           measurementUnit: (
             <span key="measurementUnit" className={handles.measurementUnit}>
               {measurementUnit}


### PR DESCRIPTION
#### What problem is this solving?

This PR is solving basePrice and listPrice for Products that have MeasurementUnit and UnitMultiplier, and added a simple text to be able to show MeasurementUnit.

#### How to test it?

See the price fixed from this specific product: [Workspace](https://dev430pr--gigadigital.myvtex.com/batata-inglesa/p)

You can see the difference at master: [Master](https://gigadigital.myvtex.com/batata-inglesa/p)


#### Screenshots or example usage:

**Before:** https://prnt.sc/10dtl4g /// https://prnt.sc/10dtle7
**After:** https://prnt.sc/10dtm9t /// https://prnt.sc/10dtmko

#### How does this PR make you feel? [:link:](http://giphy.com/)


![Dual-Wield](https://media.giphy.com/media/JUaglCIKYWwyk/giphy.gif)
