### PR TITLE
Fix selling price default message removing new variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Revert changes in `product-selling-price` default message. It was being used by external custom components that didn't provide all translation variables, breaking their code.
 
 ## [1.16.0] - 2021-03-10
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,6 @@
 {
   "store/list-price.default": "{listPriceValue}",
-  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {hasUnitMultiplier, select, true {{unitMultiplier}} false {}} {measurementUnit}} false {}}",
+  "store/selling-price.default": "{sellingPriceValue}",
   "store/spot-price.default": "Spot price: {spotPriceValue}",
   "store/spot-price-savings.default": "Spot price savings: {spotPriceSavingsValue}",
   "store/savings.default": "Save {savingsValue}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,6 +1,6 @@
 {
   "store/list-price.default": "{listPriceValue}",
-  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {hasUnitMultiplier, select, true {{unitMultiplier}} false {}} {measurementUnit}} false {}}",
+  "store/selling-price.default": "{sellingPriceValue}",
   "store/spot-price.default": "Precio en efectivo: {spotPriceValue}",
   "store/spot-price-savings.default": "Shorro de precio en efectivo: {spotPriceSavingsValue}",
   "store/savings.default": "Ahorre {savingsValue}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,6 @@
 {
   "store/list-price.default": "{listPriceValue}",
-  "store/selling-price.default": "{sellingPriceValue}{hasMeasurementUnit, select, true { / {hasUnitMultiplier, select, true {{unitMultiplier}} false {}} {measurementUnit}} false {}}",
+  "store/selling-price.default": "{sellingPriceValue}",
   "store/spot-price.default": "Preço a vista: {spotPriceValue}",
   "store/spot-price-savings.default": "Economia de preço a vista: {spotPriceSavingsValue}",
   "store/savings.default": "Economize {savingsValue}",


### PR DESCRIPTION
#### What problem is this solving?

Change default translation that some external apps used, those apps didn't provide all variables to the translation string, breaking it.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

**Before**
1. https://brenovtex--ametllerorigen.myvtex.com/?__bindingAddress=www.ametllerorigen.com/es/
2. https://brenovtex--carrefourbr.myvtex.com/smartphone-motorola-moto-e7-plus-64gb-azul-navy-4g-tela-6-5-pol-camera-dupla-48mp-selfie-8mp-android-10-0-6174418/p

**After**
1. https://brenovtex2--ametllerorigen.myvtex.com/
2. https://brenovtex2--carrefourbr.myvtex.com/smartphone-motorola-moto-e7-plus-64gb-azul-navy-4g-tela-6-5-pol-camera-dupla-48mp-selfie-8mp-android-10-0-6174418/p


#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
