### PR TITLE
Added prop and documented it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `minimumPercentage` on `product-price-savings`.
 
 ## [1.18.2] - 2021-03-30
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,11 +88,12 @@ For example:
 },
 ```
 
-The block `product-price-savings` has an additional prop:
+The block `product-price-savings` has two additional props:
 
 | Prop name          | Type      |  Description | Default value |
 | --------------------| ----------|--------------|---------------|
 | `percentageStyle` | `locale` or `compact` | Set to `compact` if you want to remove the white space between the number and the percent sign. It uses pattern provided by the current locale as default. | `locale` |
+| `minimumPercentage` | `number` | Set the minimum value for the percentage value display. If not informed, it always appears. | `0` |
 
 
 If you are using the asynchronous price feature, you can take advantage of the `product-price-suspense` and its props:

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,7 +93,7 @@ The block `product-price-savings` has two additional props:
 | Prop name          | Type      |  Description | Default value |
 | --------------------| ----------|--------------|---------------|
 | `percentageStyle` | `locale` or `compact` | Set to `compact` if you want to remove the white space between the number and the percent sign. It uses pattern provided by the current locale as default. | `locale` |
-| `minimumPercentage` | `number` | Set the minimum value for the percentage value display. If not informed, it always appears. | `0` |
+| `minimumPercentage` | `number` | Set the minimum value for the percentage value display. If not informed, it always appears. Example: `10`, savings under or equal 10% will not show up. | `0` |
 
 
 If you are using the asynchronous price feature, you can take advantage of the `product-price-suspense` and its props:

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -62,6 +62,7 @@ interface Props {
   message?: string
   markers?: string[]
   percentageStyle?: 'locale' | 'compact'
+  minimumPercentage?: number
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
 }
@@ -69,6 +70,7 @@ interface Props {
 function Savings({
   message = messages.default.id,
   markers = [],
+  minimumPercentage = 0,
   percentageStyle = 'locale',
   classes,
 }: Props) {
@@ -97,7 +99,10 @@ function Savings({
 
   const savingsPercentage = savingsValue / previousPriceValue
 
-  if (savingsValue <= 0) {
+  console.log('savingsPercentage: '+ savingsPercentage)
+  console.log('savingsValue: '+ savingsValue)
+
+  if (savingsValue <= 0 || minimumPercentage/100 >= savingsPercentage) {
     return null
   }
 

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -99,7 +99,7 @@ function Savings({
 
   const savingsPercentage = savingsValue / previousPriceValue
 
-  if (savingsValue <= 0 || minimumPercentage / 100 >= savingsPercentage) {
+  if (savingsValue <= 0 || savingsPercentage < minimumPercentage / 100) {
     return null
   }
 

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -99,10 +99,7 @@ function Savings({
 
   const savingsPercentage = savingsValue / previousPriceValue
 
-  console.log('savingsPercentage: '+ savingsPercentage)
-  console.log('savingsValue: '+ savingsValue)
-
-  if (savingsValue <= 0 || minimumPercentage/100 >= savingsPercentage) {
+  if (savingsValue <= 0 || minimumPercentage / 100 >= savingsPercentage) {
     return null
   }
 


### PR DESCRIPTION
#### What problem is this solving?

Now, we can define a minimum value for the display of the percentage value, solving the customer's pain

#### How to test it?

[Workspace](https://prsavings--paguemenos.myvtex.com/)

#### Screenshots or example usage:

Before: 
![image](https://user-images.githubusercontent.com/69531548/112994314-7f9f1a80-9140-11eb-9dc4-700cd755f789.png)

After:
![image](https://user-images.githubusercontent.com/69531548/112993486-a446c280-913f-11eb-8349-7e0e4b2c6142.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/QHE5gWI0QjqF2/giphy.gif)
