### PR TITLE
Added new message variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New variable `hasMoreThanOne` in the Installments Renderer for ICU messages, aiding in the creation of custom messages.
 
 ## [1.19.0] - 2021-04-27
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -220,6 +220,7 @@ Still, according to the example, products that doesn't have measurement unit and
 | `interestRate` | `string` | Interest rate. |
 | `paymentSystemName` | `string` | Payment System of the installments. |
 | `hasInterest` | `boolean` | Whether the installments have interest (`true`) or not (`false`). |
+| `hasMoreThanOne` | `boolean` | Whether there're more than 1 installments (`true`) or not (`false`). |
 
 - **`product-price-savings`**
 

--- a/react/components/InstallmentsRenderer.tsx
+++ b/react/components/InstallmentsRenderer.tsx
@@ -35,6 +35,8 @@ function InstallmentsRenderer({
     TotalValuePlusInterestRate,
   } = installment
 
+  const hasMoreThanOne = NumberOfInstallments > 1
+
   const hasInterest = InterestRate !== 0
 
   const interestRatePercent = InterestRate / 100
@@ -87,6 +89,7 @@ function InstallmentsRenderer({
             </span>
           ),
           hasInterest,
+          hasMoreThanOne
         }}
       />
     </span>


### PR DESCRIPTION
#### What problem is this solving?

Originally, if you had singular installments there was no way to differentiate messages using the existing variables; because the IOMessages received values that couldn't be parsed with ICU.

With these modifications, you now have a Message Variable that can be used in the ICU Messages, to differentiate plural from singular messages. 

#### How to test it?

Go to Admin -> Site editor -> Select 'product-installment' app in any 'Product-summary' -> And see the Installments message

[Develop](https://develop--eistoreqa.myvtex.com/)

An example of an ICU message:
```
{
   hasMoreThanOne, select,
   false { En 1 pago sin interés }
   true {Hasta {installmentsNumber} cuotas { hasInterest, select, true{de {installmentValue}} false{sin interés} 
   other{ } } }
   other { }
 }
```

hasMoreThanOne is now a boolean that can be use as a select to have different messages in singular and plural

#### Screenshots or example usage:

Before if you had only 1, there was no way to singularize a message:
<img width="1193" alt="before" src="https://user-images.githubusercontent.com/50715158/115780681-5aa16e80-a3b1-11eb-8434-4d1b019eea92.png">

After:
<img width="1193" alt="after" src="https://user-images.githubusercontent.com/50715158/115780674-583f1480-a3b1-11eb-8cd8-d6d616f8e90d.png">

IOMessages variables are rendered as <span /> so you cannot use PLURAL in ICU:
<img width="859" alt="iomessages" src="https://user-images.githubusercontent.com/50715158/115780687-5b3a0500-a3b1-11eb-996d-235cfadc88cc.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3o85xDWOG8Sbl9yQzm/giphy.gif)
