### PR TITLE
Feature/prices with quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- SellingPrices with Quantity
+- ListPrices with quantity
+- Savings with quantity
 ## [1.26.0] - 2021-09-24
 
 ### Added 

--- a/docs/README.md
+++ b/docs/README.md
@@ -187,6 +187,9 @@ In addition to that, keep in mind the message variables for each block since you
 | `listPriceValue` | `string` | List price value. |
 | `listPriceWithTax` | `string` | List price value with tax. |
 | `listPriceWithUnitMultiplier` | `string` | List price multiplied by unit multiplier. |
+| `listPriceValueWithQuantity` | `string` | List price value by quantity selected. |
+| `listPriceWithTaxWithQuantity` | `string` | List price value with tax by quantity selected. |
+| `listPriceWithUnitMultiplierWithQuantity` | `string` | List price multiplied by unit multiplier and quantity selected. |
 | `taxPercentage` | `string` | Tax percentage. |
 | `taxValue` | `string` | Tax value. |
 | `hasMeasurementUnit` | `boolean` | Whether the product has a measurement unit (`true`) or not (`false`). |
@@ -201,6 +204,9 @@ In addition to that, keep in mind the message variables for each block since you
 | `sellingPriceValue` | `string` | Selling price value. |
 | `sellingPriceWithTax` | `string` | Selling price with tax. |
 | `sellingPriceWithUnitMultiplier` | `string` | Selling price multiplied by unit multiplier. |
+| `sellingPriceValueWithQuantity` | `string` | Selling price value by quantity selected. |
+| `sellingPriceWithTaxWithQuantity` | `string` | Selling price with tax by quantity selected. |
+| `sellingPriceWithUnitMultiplierWithQuantity` | `string` | Selling price multiplied by unit multiplier and quantity selected. |
 | `taxPercentage` | `string` | Tax percentage. |
 | `hasListPrice` | `boolean` | Whether the product has a list price (`true`) or not (`false`). |
 | `taxValue` | `string` | Tax value. |
@@ -260,6 +266,10 @@ Still, according to the example, products that don't have a measurement unit and
 | `newPriceValue` | `string` | New price value (selling price). |
 | `savingsValue` | `string` | Difference between previous product price and the new one. |
 | `savingsWithTax` | `string` | Difference between previous product price and the new one with taxes. |
+| `previousPriceValueWithQuantity` | `string` | Previous price value (list price) by quantity selected. |
+| `newPriceValueWithQuantity` | `string` | New price value (selling price) by quantity selected. |
+| `savingsValueWithQuantity` | `string` | Difference between previous product price and the new one by quantity selected. |
+| `savingsWithTaxWithQuantity` | `string` | Difference between previous product price and the new one with taxes by quantity selected. |
 | `savingsPercentage` | `string` | Percentage of savings. |
 
 - **`product-spot-price-savings`**
@@ -328,13 +338,21 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `listPriceRange--isUnavailable` | 
 | `listPriceValue` |
 | `listPriceWithTax` | 
+| `listPriceWithUnitMultiplier` | 
+| `listPriceValueWithQuantity` |
+| `listPriceWithTaxWithQuantity` | 
+| `listPriceWithUnitMultiplierWithQuantity` | 
 | `newPriceValue` |
+| `newPriceValueWithQuantity` |
 | `newSpotPriceValue` | 
 | `paymentSystemName` |
 | `previousPriceValue` |
+| `previousPriceValueWithQuantity` |
 | `savingsPercentage` |
 | `savingsValue` |
 | `savingsWithTax` |
+| `savingsValueWithQuantity` |
+| `savingsWithTaxWithQuantity` |
 | `savings` |
 | `savings--isUnavailable` | 
 | `sellerName` |
@@ -352,6 +370,10 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `sellingPriceRange--isUnavailable` |
 | `sellingPriceValue` |
 | `sellingPriceWithTax` | 
+| `sellingPriceWithUnitMultiplier` | 
+| `sellingPriceValueWithQuantity` |
+| `sellingPriceWithTaxWithQuantity` | 
+| `sellingPriceWithUnitMultiplierWithQuantity` | 
 | `sellingPrice` |
 | `spotPriceSavingsPercentage` | 
 | `spotPriceSavingsValue` | 

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -13,6 +13,9 @@ const CSS_HANDLES = [
   'listPriceValue',
   'listPriceWithTax',
   'listPriceWithUnitMultiplier',
+  'listPriceValueWithQuantity',
+  'listPriceWithTaxWithQuantity',
+  'listPriceWithUnitMultiplierWithQuantity',
   'taxPercentage',
   'taxValue',
   'unitMultiplier',
@@ -49,6 +52,7 @@ function ListPrice({
   const productContextValue = useProduct()
 
   const seller = getDefaultSeller(productContextValue?.selectedItem?.sellers)
+  const quantity = productContextValue?.selectedQuantity || 1
 
   const commercialOffer = seller?.commertialOffer
 
@@ -85,6 +89,10 @@ function ListPrice({
   const containerClasses = withModifiers('listPrice', [
     alwaysShow && commercialOffer.AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
+
+  const listPriceWithTaxWithQuantity = (listPriceValue + listPriceValue * taxPercentage) * quantity
+  const listPriceValueWithQuantity = listPriceValue * quantity
+  const listPriceWithUnitMultiplierWithQuantity = (commercialOffer.ListPrice * unitMultiplier) * quantity
 
   return (
     <span className={containerClasses}>
@@ -137,6 +145,30 @@ function ListPrice({
           measurementUnit: (
             <span key="measurementUnit" className={handles.measurementUnit}>
               {measurementUnit}
+            </span>
+          ),
+          listPriceValueWithQuantity: (
+            <span
+              key="listPriceValueWithQuantity"
+              className={`${handles.listPriceValueWithQuantity} strike`}
+            >
+              <FormattedCurrency value={listPriceValueWithQuantity} />
+            </span>
+          ),
+          listPriceWithTaxWithQuantity: (
+            <span
+              key="listPriceWithTaxWithQuantity"
+              className={`${handles.listPriceWithTaxWithQuantity} strike`}
+            >
+              <FormattedCurrency value={listPriceWithTaxWithQuantity} />
+            </span>
+          ),
+          listPriceWithUnitMultiplierWithQuantity: (
+            <span
+              key="listPriceWithUnitMultiplierWithQuantity"
+              className={`${handles.listPriceWithUnitMultiplierWithQuantity} strike`}
+            >
+              <FormattedCurrency value={listPriceWithUnitMultiplierWithQuantity} />
             </span>
           ),
         }}

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -15,6 +15,10 @@ const CSS_HANDLES = [
   'newPriceValue',
   'savingsValue',
   'savingsWithTax',
+  'previousPriceValueWithQuantity',
+  'newPriceValueWithQuantity',
+  'savingsValueWithQuantity',
+  'savingsWithTaxWithQuantity',
   'savingsPercentage',
 ] as const
 
@@ -83,6 +87,7 @@ function Savings({
   const productSummaryValue = ProductSummaryContext.useProductSummary()
 
   const seller = getDefaultSeller(productContextValue?.selectedItem?.sellers)
+  const quantity = productContextValue?.selectedQuantity || 1
 
   const commercialOffer = seller?.commertialOffer
 
@@ -104,7 +109,6 @@ function Savings({
     savingsValue + savingsValue * commercialOffer.taxPercentage
 
   const savingsPercentage = savingsValue / previousPriceValue
-
   if (savingsValue <= 0 || savingsPercentage < minimumPercentage / 100) {
     return null
   }
@@ -112,6 +116,14 @@ function Savings({
   const containerClasses = withModifiers('savings', [
     alwaysShow && commercialOffer.AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
+
+
+  const previousPriceValueWithQuantity = commercialOffer.ListPrice * quantity
+  const newPriceValueWithQuantity = commercialOffer.Price * quantity
+  const savingsValueWithQuantity = (previousPriceValue - newPriceValue ) * quantity
+  const savingsWithTaxWithQuantity =
+    (savingsValue + savingsValue * commercialOffer.taxPercentage) * quantity
+
 
   return (
     <span className={containerClasses}>
@@ -150,6 +162,29 @@ function Savings({
                 savingsPercentage,
                 percentageStyle,
               })}
+            </span>
+          ),
+          previousPriceValueWithQuantity: (
+            <span
+              key="previousPriceValue"
+              className={handles.previousPriceValueWithQuantity}
+            >
+              <FormattedCurrency value={previousPriceValueWithQuantity} />
+            </span>
+          ),
+          newPriceValueWithQuantity: (
+            <span key="newPriceValue" className={handles.newPriceValueWithQuantity}>
+              <FormattedCurrency value={newPriceValueWithQuantity} />
+            </span>
+          ),
+          savingsValueWithQuantity: (
+            <span key="savingsValue" className={handles.savingsValueWithQuantity}>
+              <FormattedCurrency value={savingsValueWithQuantity} />
+            </span>
+          ),
+          savingsWithTaxWithQuantity: (
+            <span key="savingsWithTax" className={handles.savingsWithTaxWithQuantity}>
+              <FormattedCurrency value={savingsWithTaxWithQuantity} />
             </span>
           ),
         }}

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -13,6 +13,9 @@ const CSS_HANDLES = [
   'sellingPriceValue',
   'sellingPriceWithTax',
   'sellingPriceWithUnitMultiplier',
+  'sellingPriceValueWithQuantity',
+  'sellingPriceWithTaxWithQuantity',
+  'sellingPriceWithUnitMultiplierWithQuantity',
   'taxPercentage',
   'taxValue',
   'measurementUnit',
@@ -52,6 +55,7 @@ function SellingPrice({
   const productContextValue = useProduct()
 
   const seller = getDefaultSeller(productContextValue?.selectedItem?.sellers)
+  const quantity = productContextValue?.selectedQuantity || 1
 
   const commercialOffer = seller?.commertialOffer
 
@@ -89,6 +93,11 @@ function SellingPrice({
     hasUnitMultiplier ? 'hasUnitMultiplier' : '',
     alwaysShow && commercialOffer.AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
+
+  const sellingPriceValueWithQuantity = commercialOffer.Price * quantity
+  const sellingPriceWithUnitMultiplierWithQuantity = commercialOffer.ListPrice  * quantity
+  const sellingPriceWithTaxWithQuantity =
+    (sellingPriceValue + sellingPriceValue * taxPercentage)  * quantity
 
   return (
     <span className={containerClasses}>
@@ -139,6 +148,27 @@ function SellingPrice({
           measurementUnit: (
             <span key="measurementUnit" className={handles.measurementUnit}>
               {measurementUnit}
+            </span>
+          ),
+          sellingPriceValueWithQuantity: (
+            <span key="sellingPriceValue" className={handles.sellingPriceValueWithQuantity}>
+              <FormattedCurrency value={sellingPriceValueWithQuantity} />
+            </span>
+          ),
+          sellingPriceWithTaxWithQuantity: (
+            <span
+              key="sellingPriceWithTax"
+              className={handles.sellingPriceWithTaxWithQuantity}
+            >
+              <FormattedCurrency value={sellingPriceWithTaxWithQuantity} />
+            </span>
+          ),
+          sellingPriceWithUnitMultiplierWithQuantity: (
+            <span
+              key="sellingPriceWithUnitMultiplier"
+              className={handles.sellingPriceWithUnitMultiplierWithQuantity}
+            >
+              <FormattedCurrency value={sellingPriceWithUnitMultiplierWithQuantity} />
             </span>
           ),
         }}


### PR DESCRIPTION
## What problem is this solving?

When you change the quantity you do not see the possible sale price before adding it to the cart

![image](https://user-images.githubusercontent.com/33559104/135247702-42e3945f-d3be-447f-8495-623b53209ef7.png)
![image](https://user-images.githubusercontent.com/33559104/135247742-000bbc54-ceff-438a-b875-c3cf3043b879.png)

## Proposed solution

Use the **selectedQuantity** to multiply on some prices values

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/33559104/135248271-82102ec7-2974-4dbf-b103-a4c9e27ddebd.png)

That is the unique problem, if you have discounts by quantity can't see it before adding on cart. maybe a description text can be a solution 
![image](https://user-images.githubusercontent.com/33559104/135248745-c6c41e29-b9c0-4cfe-a307-5882d50beb39.png)

