### PR TITLE
displayStyle and numberOfDecimals on product-price-savings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `displayStyle` and `numberOfDecimals` props on `product-price-savings`
 
 ## [1.26.0] - 2021-09-24
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,12 +88,14 @@ For example:
 },
 ```
 
-The block `product-price-savings` has two additional props:
+The block `product-price-savings` has four additional props:
 
 | Prop name          | Type      |  Description | Default value |
 | --------------------| ----------|--------------|---------------|
 | `percentageStyle` | `locale` or `compact` | Set to `compact` if you want to remove the white space between the number and the percent sign. It uses pattern provided by the current locale as default. | `locale` |
 | `minimumPercentage` | `number` | Set the minimum value for the percentage value display. If not informed, it always appears. Example: `10`, savings under or equal 10% will not show up. | `0` |
+| `displayStyle` | `percent` or `decimal` | Set to `decimal` if you want to display number with decimals | `percent` |
+| `numberOfDecimals` | `number` | Number of decimals to display if `displayStyle` is `decimal` | `2` |
 
 The following blocks `product-list-price`, `product-selling-price`, `product-spot-price`, `product-spot-price-savings`, `product-price-savings`, `product-list-price-range`, and `product-selling-price-range` have an additional prop:
 

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -38,31 +38,46 @@ interface GetFormattedSavingsPercentageParams {
   formatNumber: IntlFormatters['formatNumber']
   savingsPercentage: number
   percentageStyle: Props['percentageStyle']
+  displayStyle: Props['displayStyle']
+  numberOfDecimals: Props['numberOfDecimals']
 }
 
 function getFormattedSavingsPercentage({
   formatNumber,
   savingsPercentage,
   percentageStyle,
+  displayStyle,
+  numberOfDecimals
 }: GetFormattedSavingsPercentageParams) {
-  const formattedSavingsPercentage = formatNumber(savingsPercentage, {
-    style: 'percent',
-  })
+    let finalNumber = '';
+    const formattedSavingsPercentage = formatNumber(savingsPercentage, {
+      style: displayStyle
+    })
 
-  if (percentageStyle === 'compact') {
-    return formattedSavingsPercentage.replace(
-      `${NON_BREAKING_SPACE_CHAR}%`,
-      '%'
-    )
+  if(displayStyle === 'decimal') {
+    const number = savingsPercentage * 100;
+    const numberWithDecimals = parseFloat(number.toFixed(numberOfDecimals)).toLocaleString();
+    finalNumber = `${numberWithDecimals} %`
+  } else {
+    finalNumber = formattedSavingsPercentage
   }
 
-  return formattedSavingsPercentage
+  if (percentageStyle === 'compact') {
+    return finalNumber.replace(
+      `${NON_BREAKING_SPACE_CHAR}%`,
+      '%'
+    ).replace(' %', '%')
+  }
+
+  return finalNumber
 }
 
 interface Props {
   message?: string
   markers?: string[]
   percentageStyle?: 'locale' | 'compact'
+  displayStyle?: 'percent' | 'decimal'
+  numberOfDecimals?: number
   minimumPercentage?: number
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
@@ -74,6 +89,8 @@ function Savings({
   markers = [],
   minimumPercentage = 0,
   percentageStyle = 'locale',
+  displayStyle = 'percent',
+  numberOfDecimals = 2,
   classes,
   alwaysShow = false,
 }: Props) {
@@ -149,6 +166,8 @@ function Savings({
                 formatNumber,
                 savingsPercentage,
                 percentageStyle,
+                displayStyle,
+                numberOfDecimals
               })}
             </span>
           ),


### PR DESCRIPTION
#### What problem is this solving?

These props allow us to display the discount with decimals.


```
"product-price-savings": {
    "props": {
      "message": "-{savingsPercentage}",
      "displayStyle": "decimal"
    }
  },
```

![decimal](https://user-images.githubusercontent.com/43498488/137105842-da3eb03d-b4db-4070-9702-dbf59326a1db.jpg)


