### PR TITLE
add hasListPrice handle on product-selling-price-range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `hasListPrice` on `product-selling-price-range`.
+
 ## [1.28.0] - 2022-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `hasListPrice` on `product-selling-price-range`.
+- `hasListPrice`  on  `product-selling-price-range`.
 
 ## [1.28.0] - 2022-06-01
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -350,6 +350,7 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `sellingPriceRangeUniqueWithTax` |
 | `sellingPriceRange` |
 | `sellingPriceRange--isUnavailable` |
+| `sellingPriceRange--hasListPrice` |
 | `sellingPriceValue` |
 | `sellingPriceWithTax` | 
 | `sellingPrice` |

--- a/react/SellingPriceRange.tsx
+++ b/react/SellingPriceRange.tsx
@@ -83,6 +83,9 @@ function SellingPriceRange({
     return null
   }
 
+  const sellingPriceValue = commercialOffer.Price
+  const listPriceValue = commercialOffer.ListPrice
+  const hasListPrice = sellingPriceValue !== listPriceValue
   const minPrice: number = priceRange.sellingPrice.lowPrice
   const maxPrice: number = priceRange.sellingPrice.highPrice
   const hasRange = minPrice !== maxPrice
@@ -94,6 +97,7 @@ function SellingPriceRange({
     commercialOffer.PriceWithoutDiscount * commercialOffer.taxPercentage
 
   const containerClasses = withModifiers('sellingPriceRange', [
+    hasListPrice ? 'hasListPrice' : '',
     alwaysShow && commercialOffer.AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
 
@@ -153,6 +157,7 @@ function SellingPriceRange({
                 <FormattedCurrency value={sellingPriceWithTax} />
               </span>
             ),
+            hasListPrice,
           }}
         />
       </span>


### PR DESCRIPTION
#### What problem is this solving?

Adding a hasListPrice CSS handle on product-selling-price-range

#### How to test it?

Inspect the `vtex-product-price-1-x-sellingPriceRange` that now has the `vtex-product-price-1-x-sellingPriceRange--hasListPrice` handle

[Workspace](https://price--alssports.myvtex.com/patagn-shirt-line-logo-ridge-pocket/p?skuId=826044)

#### Screenshots or example usage:

<img width="1165" alt="Screen Shot 2022-06-15 at 1 35 48 AM" src="https://user-images.githubusercontent.com/18540163/173711993-f048269b-ab49-413f-8337-26915899e3b9.png">

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
