### PR TITLE
feat: add Selling and List Price With Tax Without UnitMultiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `sellingPriceWithTaxWithoutUnitMultiplier` and `listPriceWithTaxWithoutUnitMultiplier`
+
 ## [1.32.1] - 2025-09-09
 ### Fixed
 - improved some of the German Translations

--- a/docs/README.md
+++ b/docs/README.md
@@ -186,6 +186,7 @@ In addition, remember to take into account the message variables for each block,
 | `listPriceValue`              | `string`  | List price value.                                                                                |
 | `listPriceWithTax`            | `string`  | List price value with tax.                                                                       |
 | `listPriceWithUnitMultiplier` | `string`  | List price multiplied by a unit multiplier.                                                      |
+| `listPriceWithTaxWithoutUnitMultiplier` | `string`  | List price with tax without unit multiplier.                                           |
 | `taxPercentage`               | `string`  | Tax percentage.                                                                                  |
 | `taxValue`                    | `string`  | Tax value.                                                                                       |
 | `hasMeasurementUnit`          | `boolean` | Determines whether the product has a unit of measure (`true`) or not (`false`).                  |
@@ -201,6 +202,7 @@ In addition, remember to take into account the message variables for each block,
 | `sellingPriceWithTax`            | `string`  | Selling price with tax.                                                                          |
 | `sellingPriceWithUnitMultiplier` | `string`  | Selling price multiplied by a unit multiplier.                                                   |
 | `sellingPriceWithUnitMultiplierAndTax` | `string` | Selling price multiplied by a unit multiplier and added tax. |
+| `sellingPriceWithTaxWithoutUnitMultiplier` | `string` | Selling price with tax without unit multiplier. |
 | `taxPercentage`                  | `string`  | Tax percentage.                                                                                  |
 | `hasListPrice`                   | `boolean` | Determines whether the product has a list price (`true`) or not (`false`).                       |
 | `taxValue`                       | `string`  | Tax value.                                                                                       |

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -79,8 +79,7 @@ function ListPrice({
   const hasMeasurementUnit = measurementUnit && measurementUnit !== 'un'
   const hasUnitMultiplier = unitMultiplier !== 1
   
-  const listPriceWithTaxWithoutUnitMultiplier = 
-  listPriceValue * (1 + taxPercentage)
+  const listPriceWithTaxWithoutUnitMultiplier = listPriceValue + (listPriceValue * taxPercentage / unitMultiplier)
 
   if (listPriceValue <= sellingPriceValue) {
     return null

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -13,6 +13,7 @@ const CSS_HANDLES = [
   'listPriceValue',
   'listPriceWithTax',
   'listPriceWithUnitMultiplier',
+  'listPriceWithTaxWithoutUnitMultiplier',
   'taxPercentage',
   'taxValue',
   'unitMultiplier',
@@ -77,6 +78,9 @@ function ListPrice({
 
   const hasMeasurementUnit = measurementUnit && measurementUnit !== 'un'
   const hasUnitMultiplier = unitMultiplier !== 1
+  
+  const listPriceWithTaxWithoutUnitMultiplier = 
+  listPriceValue * (1 + taxPercentage)
 
   if (listPriceValue <= sellingPriceValue) {
     return null
@@ -109,6 +113,14 @@ function ListPrice({
               className={`${handles.listPriceWithTax} strike`}
             >
               <FormattedCurrency value={listPriceWithTax} />
+            </span>
+          ),
+          listPriceWithTaxWithoutUnitMultiplier: (
+            <span
+              key="listPriceWithTaxWithoutUnitMultiplier"
+              className={`${handles.listPriceWithTaxWithoutUnitMultiplier} strike`}
+            >
+              <FormattedCurrency value={listPriceWithTaxWithoutUnitMultiplier} />
             </span>
           ),
           listPriceWithUnitMultiplier: (

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -14,6 +14,7 @@ const CSS_HANDLES = [
   'sellingPriceWithTax',
   'sellingPriceWithUnitMultiplier',
   'sellingPriceWithUnitMultiplierAndTax',
+  'sellingPriceWithTaxWithoutUnitMultiplier',
   'taxPercentage',
   'taxValue',
   'measurementUnit',
@@ -80,7 +81,10 @@ function SellingPrice({
 
   const sellingPriceWithUnitMultiplierAndTax =
   sellingPriceValue * (unitMultiplier + taxPercentage)
-
+  
+  const sellingPriceWithTaxWithoutUnitMultiplier =
+  sellingPriceValue * (1 + taxPercentage)
+  
   const taxValue = commercialOffer.Tax
 
   const hasListPrice = sellingPriceValue !== listPriceValue
@@ -128,6 +132,14 @@ function SellingPrice({
               className={handles.sellingPriceWithUnitMultiplierAndTax}
             >
               <FormattedCurrency value={sellingPriceWithUnitMultiplierAndTax} />
+            </span>
+          ),
+          sellingPriceWithTaxWithoutUnitMultiplier: (
+            <span
+              key="sellingPriceWithTaxWithoutUnitMultiplier"
+              className={handles.sellingPriceWithTaxWithoutUnitMultiplier}
+            >
+              <FormattedCurrency value={sellingPriceWithTaxWithoutUnitMultiplier} />
             </span>
           ),
           taxPercentage: (

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -83,7 +83,7 @@ function SellingPrice({
   sellingPriceValue * (unitMultiplier + taxPercentage)
   
   const sellingPriceWithTaxWithoutUnitMultiplier =
-  sellingPriceValue * (1 + taxPercentage)
+  sellingPriceValue + (sellingPriceValue * taxPercentage / unitMultiplier)
   
   const taxValue = commercialOffer.Tax
 


### PR DESCRIPTION
#### What problem is this solving?

I've added a new handle for `sellingPriceWithTaxWithoutUnitMultiplier` and `listPriceWithTaxWithoutUnitMultiplier` that allows the display of a product that has a unit multiplier and also taxes. The default `sellingPriceWithTax` calculates the taxes for the entire quantity, not for 1 unit.

#### How to test it?
You can link the app from this branch on a dev workspace and change the price block configuration on a PDP. The product you are viewing must have a unit multiplier different from 1 and also active taxes.

You can check out this product that has a 5,0 unit multiplier, 100 ron price and a 10% tax.
You can notice the calculation using the default {sellingPriceWithTax} will display the price for 1 unit but the tax for all 5 units
https://vtexromania.myvtex.com/rama-foto-argintata-jardin-d-eden-christofle/p 

<img width="969" alt="Screenshot 2023-06-15 at 13 18 52" src="https://github.com/vtex-apps/product-price/assets/84322200/53e1ba5c-83d8-4ffa-aa70-d2ffbda3ff32">


Checking the new sellingPriceWithTaxWithoutUnitMultiplier you will see the correct calculation for 1 unit + 1 unit tax
https://mihaitest--vtexromania.myvtex.com/rama-foto-argintata-jardin-d-eden-christofle/p 

<img width="969" alt="Screenshot 2023-06-15 at 13 19 02" src="https://github.com/vtex-apps/product-price/assets/84322200/ea9f2d0b-92f7-4007-b883-e8d180e74133">

#### Related to / Depends on
This PR is related to #121 

